### PR TITLE
[spirv-headers] 2:1.3.246.1: downgrade to match spirv-tools version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 
 _pkg=SPIRV-Headers
 pkgname=spirv-headers
-epoch=1
-pkgver=1.3.261.1
+epoch=2
+pkgver=1.3.246.1
 pkgrel=1
 pkgdesc="SPIR-V Headers"
 arch=(any)
@@ -11,7 +11,7 @@ url="https://www.khronos.org/registry/spir-v/"
 license=(MIT)
 makedepends=(cmake)
 source=(https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-${pkgver}/${pkgname}-${pkgver}.tar.gz)
-sha512sums=('46d14e993d58e641ec4d2bb96e76f4f2bd8426fb1e33b77e7d053cea80dcf5ffae3d4d6136559d4a66387fba3a4e4a4a74ad5af83445a3be0d171e47414599e1')
+sha512sums=('436c6ce11d918091ce4a5ef2821f51af811c9a289e220b4a2b0bb4417b1f9f3b1f56a6366cfdf56848a9b1fb612ee3ba31d35c3d73d3d24de964ee05f96a7bbc')
 
 build() {
   cmake -B build -S ${_pkg}-sdk-${pkgver} -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
spirv-tools 2023.2 requires spirv-headers 1.3.246.1