### PR TITLE
[libseat] 0.8.0-4: ignore takedevice for elogind

### DIFF
--- a/0_logind-no-takedevice.patch
+++ b/0_logind-no-takedevice.patch
@@ -1,0 +1,59 @@
+--- a/libseat/backend/logind.c
++++ b/libseat/backend/logind.c
+@@ -119,54 +119,14 @@
+ static int open_device(struct libseat *base, const char *path, int *fd) {
+ 	struct backend_logind *session = backend_logind_from_libseat_backend(base);
+ 
+-	int ret;
+-	int tmpfd = -1;
+-	sd_bus_message *msg = NULL;
+-	sd_bus_error error = SD_BUS_ERROR_NULL;
+-
+-	struct stat st;
+-	if (stat(path, &st) < 0) {
+-		log_errorf("Could not stat path '%s'", path);
+-		return -1;
+-	}
+-
+-	ret = sd_bus_call_method(session->bus, "org.freedesktop.login1", session->path,
+-				 "org.freedesktop.login1.Session", "TakeDevice", &error, &msg, "uu",
+-				 major(st.st_rdev), minor(st.st_rdev));
+-	if (ret < 0) {
+-		log_errorf("Could not take device: %s", error.message);
+-		tmpfd = -1;
+-		goto out;
+-	}
+-
+-	int paused = 0;
+-	ret = sd_bus_message_read(msg, "hb", &tmpfd, &paused);
+-	if (ret < 0) {
+-		log_errorf("Could not parse D-Bus response: %s", strerror(-ret));
+-		tmpfd = -1;
+-		goto out;
+-	}
+-
+-	// The original fd seems to be closed when the message is freed
+-	// so we just clone it.
+-	tmpfd = fcntl(tmpfd, F_DUPFD_CLOEXEC, 0);
++	int tmpfd = open(path, O_RDWR | O_NOCTTY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+ 	if (tmpfd < 0) {
+-		log_errorf("Could not duplicate fd: %s", strerror(errno));
+-		tmpfd = -1;
+-		goto out;
+-	}
+-
+-	if (dev_is_drm(st.st_rdev)) {
+-		session->has_drm++;
+-		log_debugf("DRM device opened, current total: %d", session->has_drm);
++		log_errorf("Failed to open device: %s", strerror(errno));
++		return -1;
+ 	}
+ 
+ 	*fd = tmpfd;
+-
+-out:
+-	sd_bus_error_free(&error);
+-	sd_bus_message_unref(msg);
+	check_pending_events(session);
+ 	return tmpfd;
+ 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=libseat
 pkgbase=seatd
 pkgver=0.8.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A minimal seat management daemon, and a universal seat management library"
 arch=(x86_64 aarch64 riscv64)
 url="https://sr.ht/~kennylevinsen/seatd/"
@@ -13,8 +13,15 @@ makedepends=('meson' 'ninja' 'scdoc')
 provides=('seatd')
 source=(
   "$pkgbase-$pkgver.tar.gz::https://git.sr.ht/~kennylevinsen/$pkgbase/archive/$pkgver.tar.gz"
+  0_logind-no-takedevice.patch
 )
-sha256sums=('a562a44ee33ccb20954a1c1ec9a90ecb2db7a07ad6b18d0ac904328efbcf65a0')
+sha256sums=('a562a44ee33ccb20954a1c1ec9a90ecb2db7a07ad6b18d0ac904328efbcf65a0'
+            'c7077bb9ac7eaba0e9b51989804d634d34cef7eecf25914a8a2b83eeedad8b59')
+
+prepare()
+{
+  _patch_ $pkgbase-$pkgver
+}
 
 build()
 {


### PR DESCRIPTION
`elogind` requires `udev` for `takedevice`, use code from `noop` backend to skip it (need add user to input/video group manually)