### PR TITLE
[c-ares] 1.26.0-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 # Contributor: Alexander Fehr <pizzapunk gmail com>
 
 pkgname=c-ares
-pkgver=1.24.0
+pkgver=1.26.0
 pkgrel=1
 pkgdesc="A C library for asynchronous DNS requests"
 arch=(x86_64 aarch64 riscv64)
@@ -16,7 +16,7 @@ depends=('musl')
 makedepends=('cmake')
 provides=('libcares.so')
 source=("https://github.com/${pkgname}/${pkgname}/releases/download/${pkgname//-/}-${pkgver//./_}/${pkgname}-${pkgver}.tar.gz")
-sha512sums=('3701853e263de94daf19734185ad913848c19b825e0738926b418a54b0628ee1ac95a49ebfaa2ddf3eed74a7ef209e1a0a8f573df3e507ef1f11fcc53fc5eb68')
+sha512sums=('81657b8b9840a565b04ecf87ef8f0fc3192a9594808e47aed5e5bbebf2b5f0066b0cd5fae70f0fe70b68d428b4cc75fba22d2ae7683c6d0f87979c414c072af1')
 
 build()
 {
@@ -41,6 +41,6 @@ package()
   cd "$pkgname-$pkgver"
   make DESTDIR="${pkgdir}" install -C build
   install -vDm 644 "LICENSE.md" -t "${pkgdir}/usr/share/licenses/${pkgname}/"
-  install -vDm 644 {AUTHORS,CHANGES,{CONTRIBUTING,README}.md,RELEASE-NOTES} \
+  install -vDm 644 {AUTHORS,CHANGES,{CONTRIBUTING,README,RELEASE-NOTES}.md} \
     -t "${pkgdir}/usr/share/doc/${pkgname}/"
 }


### PR DESCRIPTION
RELEASE-NOTES is renamed as RELEASE-NOTES.md, so fix it in package()