### PR TITLE
[busybox] 1.36.1-15: fix depmod buffer size

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=busybox
 pkgver=1.36.1
-pkgrel=14
+pkgrel=15
 pkgdesc="Utilities for rescue and embedded systems"
 arch=(x86_64 aarch64 riscv64)
 url="https://www.busybox.net"
@@ -57,6 +57,8 @@ prepare()
     scripts/trylink
   # Fix eweOS/bugs/#2
   patch -p1 < ../remove_empty_dir.patch
+  # Fix depmod: buffer 67104768 too small with gz modules
+  sed -i 's/64*1024*1024/512*1024*1024/' modutils/depmod.c
 }
 
 build()


### PR DESCRIPTION
fix: `depmod: buffer 67104768 too small`