### PR TITLE
[util-linux] 2.40.1-1: new upstream version, enable fdisk

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,34 +2,31 @@
 # Maintainer: Aleksana QwQ <me@aleksana.moe>
 
 pkgname=(util-linux util-linux-libs)
-pkgver=2.38.1
+pkgver=2.40.1
 pkgrel=1
 pkgdesc='Miscellaneous system utilities for Linux'
 arch=(x86_64 aarch64 riscv64)
 url=https://github.com/karelzak/util-linux
 license=(GPL)
-makedepends=(
-  bison
-  gettext
-  libtool
-)
+makedepends=('bison' 'gettext' 'libtool' 'sqlite' 'linux-headers')
+source=("util-linux-${pkgver}.tar.gz::https://github.com/karelzak/util-linux/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('61f815bbfaabad7a6a56af6cb5c5bc7e2d26ae764b1e59901fd809ac3fd55f68')
 
-_command_needed=('addpart' 'agetty' 'cfdisk' 'chcpu' 'chmem' 'choom' 'col' 'colcrt' 'colrm' 'column'
-  'ctrlaltdel' 'delpart' 'eject' 'fincore' 'findfs' 'findmnt' 'fsck.cramfs'
+_command_needed=(
+  'addpart' 'agetty' 'cfdisk' 'chcpu' 'chmem' 'choom' 'col' 'colcrt' 'colrm' 'column'
+  'ctrlaltdel' 'delpart' 'eject' 'fdisk' 'fincore' 'findfs' 'findmnt' 'fsck.cramfs'
   'hardlink' 'ipcmk' 'ipcrm' 'ipcs' 'irqtop' 'isosize' 'ldattach' 'look' 'lsblk' 'lscpu' 'lsipc'
   'lsirq' 'lslocks' 'lslogins' 'lsmem' 'lsns' 'mcookie' 'mkfs' 'mkfs.bfs' 'mkfs.cramfs'
   'mkfs.minix' 'namei' 'nologin' 'nsenter' 'partx' 'prlimit' 'raw' 'rename' 'resizepart'
   'scriptlive' 'setterm' 'sfdisk' 'sulogin' 'uclampset' 'ul' 'uuidgen' 'uuidd' 'uuidparse'
-  'wdctl' 'whereis' 'wipefs' 'zramctl')
-
-source=(
-  "util-linux-${pkgver}.tar.gz::https://github.com/karelzak/util-linux/archive/refs/tags/v${pkgver}.tar.gz"
+  'wdctl' 'whereis' 'wipefs' 'zramctl'
 )
 
-sha256sums=('75add98ee04e8ca742e860dd06936379737465149904152175a64708de399125')
+prepare() {
+  _patch_ "${pkgbase}-${pkgver}"
+}
 
-build()
-{
+build() {
   cd "${pkgbase}-${pkgver}"
   ./autogen.sh
   ./configure \
@@ -43,8 +40,7 @@ build()
   make
 }
 
-package_util-linux()
-{
+package_util-linux() {
   depends=('util-linux-libs')
   cd "${pkgbase}-${pkgver}"
 
@@ -62,9 +58,8 @@ package_util-linux()
   mv "${pkgdir}"/usr/include "${srcdir}"/include
 }
 
-package_util-linux-libs()
-{
-  provides=('libutil-linux')
+package_util-linux-libs() {
+  provides=('libutil-linux' lib{blkid,fdisk,lastlog2,mount,smartcols,uuid}.so)
   make -C "${pkgbase}-${pkgver}" DESTDIR="${pkgdir}" install-usrlib_execLTLIBRARIES
   mv "${srcdir}"/include "${pkgdir}"/usr/include
 }


### PR DESCRIPTION
Change fdisk implementation from BusyBox to util-linux.

Also added soname provides to util-linux-libs.