### PR TITLE
[git] 2.45.1-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=git
-pkgver=2.45.0
+pkgver=2.45.1
 pkgrel=1
 pkgdesc='the fast distributed version control system'
 arch=(x86_64 aarch64 riscv64)
@@ -11,7 +11,7 @@ depends=('curl' 'expat' 'perl' 'perl-error'
   'openssl' 'pcre2' 'zlib')
 makedepends=('python')
 source=("https://www.kernel.org/pub/software/scm/git/git-${pkgver}.tar.xz")
-sha256sums=('0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429')
+sha256sums=('e64d340a8e627ae22cfb8bcc651cca0b497cf1e9fdf523735544ff4a732f12bf')
 
 _make_paths=(
   prefix='/usr'


### PR DESCRIPTION
Fixes CVE-2024-32002, CVE-2024-32004, CVE-2024-32465, CVE-2024-32020 and CVE-2024-32021