### PR TITLE
[skalibs] 2.14.1.1-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=skalibs
-pkgver=2.12.0.1
+pkgver=2.14.1.1
 pkgrel=1
 pkgdesc='A library suite supporting skarnet.org software.'
 arch=(x86_64 aarch64 riscv64)
+provides=(libskarnet.so)
 url=http://skarnet.org/software/skalibs/
 license=(ISC)
 
@@ -12,7 +13,7 @@ source=(
   "http://skarnet.org/software/skalibs/skalibs-${pkgver}.tar.gz"
 )
 
-sha256sums=('3e228f72f18d88c17f6c4e0a66881d6d3779427b7e7e889f3142b6f26da30285')
+sha256sums=('b6b79b816f4ba0b6801676b0ed4179b59c8c7809eeffe26db672e404636befc3')
 
 build()
 {


### PR DESCRIPTION
ABI changes, need rebuild: utmps