### PR TITLE
[ttf-unifont] 15.0.06-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=ttf-unifont
-pkgver=15.0.01
+pkgver=15.0.06
 pkgrel=1
 pkgdesc="TrueType version of the GNU Unifont"
 url="https://unifoundry.com/unifont.html"
 arch=('any')
 license=('GPL')
 source=("https://ftpmirror.gnu.org/gnu/unifont/unifont-$pkgver/unifont-$pkgver.tar.gz")
-sha256sums=('7d11a924bf3c63ea7fdf2da2b96d6d4986435bedfd1e6816c8ac2e6db47634d5')
+sha256sums=('36668eb1326d22e1466b94b3929beeafd10b9838bf3d41f4e5e3b52406ae69f1')
 
 package() {
 	install -d "$pkgdir/usr/share/fonts/unifont/"


### PR DESCRIPTION
Notice: 15.0.06 is the latest version with prebuilt TTF fonts.