### PR TITLE
[greetd] 0.9.0-11: use turnstile to replace pam_rundir and dinit-user…

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=greetd
 pkgver=0.9.0
-pkgrel=10
+pkgrel=11
 pkgdesc="Generic greeter daemon"
 arch=(x86_64 aarch64 riscv64)
 url="https://git.sr.ht/~kennylevinsen/greetd"
@@ -14,11 +14,11 @@ source=(
   greetd.sysusers
 )
 sha256sums=('a0cec141dea7fd7838b60a52237692d0fd5a0169cf748b8f8379d8409a3768eb'
-            '403b7e5cf326a46278219a4951ae667b9d1abd58f9126a0cf71444cc243857ca'
-            '571de25a9700c132b24194c8c75ddc0edef9599b02b89a8830c23b06a9d599ad'
+            '4e71e90a060b82edc0c1794fef812e286c606d3f07493ef536b9909238e2189f'
+            'a413aedea2ed6a24f6da43f1eeb357195559eb7f31d50c57e102801ebbfb1614'
             '703be69c0bfe1bba1815090113513a495f87198bfb46b02918634f56f5232fea')
 depends=(pam)
-optdepends=('dinit-userserv: user service auto-starting support')
+optdepends=('turnstile: user service and session manager support')
 makedepends=(rust)
 options=(emptydirs)
 
@@ -28,8 +28,6 @@ build() {
 }
 
 package() {
-  # To provide initial XDG env
-  depends+=(pam_rundir)
   install -Dm755 "$srcdir/greetd-$pkgver/target/release/greetd" \
     "$pkgdir/usr/bin/greetd"
   install -Dm755 "$srcdir/greetd-$pkgver/target/release/agreety" \

--- a/greetd.pam
+++ b/greetd.pam
@@ -1,7 +1,6 @@
 #%PAM-1.0
 
-session    optional     pam_rundir.so
-session    optional     pam_dinit_userservd.so
+session    optional     pam_turnstile.so
 
 auth       include      login
 account    include      login

--- a/greetd.service
+++ b/greetd.service
@@ -1,6 +1,5 @@
 type = process
 command = greetd
 depends-on = rc.target
-depends-on = seatd
 waits-for.d = /usr/lib/dinit/system/greetd.d
 before = login.target


### PR DESCRIPTION
…servd