### PR TITLE
[wayfire] 0.8.1.r316.44e1fa9c-2: fix pkgver(), use -O0 to avoid clang…

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,8 +1,9 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=wayfire
-pkgver=0.8.1
-pkgrel=1
+pkgver=0.8.1.r316.44e1fa9c
+_pkgver=0.8.1
+pkgrel=2
 pkgdesc="A modular and extensible wayland compositor"
 arch=(x86_64 aarch64 riscv64)
 url=https://wayfire.org
@@ -10,17 +11,20 @@ license=(MIT)
 depends=(cairo pango libjpeg libinput wlroots wf-config nlohmann-json)
 makedepends=(meson ninja wayland-protocols glm cmake mesa doctest git openmp linux-headers)
 _commit="44e1fa9c62e1f8c9f35cedbf3e86c6a0247e0b79"
+_refcommit="01726528ace8ed71216f23c3b0fb3344cda5a461" # v0.8.1
 source=("git+https://github.com/WayfireWM/${pkgname}.git#commit=$_commit")
 sha256sums=('SKIP')
 
 pkgver()
 {
   cd $pkgname
-  printf "$pkgver.r%s.%s" "$(git rev-list --count v$pkgver..HEAD)" "$(git rev-parse --short HEAD)"
+  printf "$_pkgver.r%s.%s" "$(git rev-list --count $_refcommit..HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 build()
 {
+  export CFLAGS="${CFLAGS/-O? /-O0 }"
+  export CXXFLAGS="${CXXFLAGS/-O? /-O0 }"
   ewe-meson "${pkgname}" build \
     -Duse_system_wlroots=enabled \
     -Dxwayland=disabled
@@ -40,3 +44,4 @@ package()
   install -Dm644 wayfire.ini "${pkgdir}/usr/share/${pkgname}/wayfire.ini"
   install -Dm645 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }
+


### PR DESCRIPTION
… issue