### PR TITLE
[utmps] 0.1.2.2-2: fix services

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=utmps
 pkgver=0.1.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc='An implementation of the utmpx.h family of functions performing user accounting'
 arch=(x86_64 aarch64 riscv64)
 url='http://skarnet.org/software/utmps/'
@@ -20,12 +20,12 @@ source=(
 )
 
 sha256sums=('f7ffa3714c65973bb95fbcf1501c06fc0478d93a51cea1b373ec6811c2425f52'
-            '784f874b49116de99553ace447435b00ceede9b49a14693838777ff3e5595d94'
-            'f3bc889b5107e104a3fdfa92907799004354312f08d2408b1c173d44b025860a'
-            'fed60c9427ae050679731375ff28195dda1734dcc700c489f0f82d99b03bf18a'
-            '51e3ec061e78cb8052a757e3fa2c9cb22c428d4314f8be02f9844d393feab393'
-            'b9b885065456df4d54bc68fd96cfdd9111d9cd300f6225a79e5b8cd2afa538aa'
-            '3f613b6eb542e7d71012014f1ecbe6d7fbea543e540b69139408c61666e21d3e')
+	    '77ced4656183e8e3fe4f59adacdbea79f4f620fac3aa8267b5e7a34d1616e395'
+	    '94e732ac7fc0855ce05e2dd118c80828938178a1a4d5282f226149d15671e01b'
+	    '03b6de41549ab28c8b30e6ed551a4508611bdc7618e8cd9c5816a2b600ff4f9a'
+	    '51e3ec061e78cb8052a757e3fa2c9cb22c428d4314f8be02f9844d393feab393'
+	    'b9b885065456df4d54bc68fd96cfdd9111d9cd300f6225a79e5b8cd2afa538aa'
+	    '3f613b6eb542e7d71012014f1ecbe6d7fbea543e540b69139408c61666e21d3e')
 
 prepare()
 {

--- a/utmpd.service
+++ b/utmpd.service
@@ -1,5 +1,5 @@
 type = process
-command = tty2socket /run/utmps/.utmpd-socket utmps-utmpd
+command = tty2socket -m 777 --s6 /run/utmps/.utmpd-socket utmps-utmpd
 working-dir = /run/utmps
 run-as = utmp
 depends-ms = pawprint

--- a/utmps.tmpfiles
+++ b/utmps.tmpfiles
@@ -1,2 +1,4 @@
 d! /run/utmps 0664 utmp utmp -
+f /run/utmps/utmp 0664 utmp utmp -
+f /run/utmps/wtmp 0664 utmp utmp -
 f /var/log/wtmp 0640 utmp utmp -

--- a/wtmpd.service
+++ b/wtmpd.service
@@ -1,5 +1,5 @@
 type = process
-command = tty2socket /run/utmps/.wtmpd-socket utmps-wtmpd
+command = tty2socket -m 777 --s6 /run/utmps/.wtmpd-socket utmps-wtmpd
 working-dir = /run/utmps
 run-as = utmp
 depends-on = pawprint


### PR DESCRIPTION
Correct tty2socket options in service files to pass environment variables to utmps-utmpd. Add tmpfile entries for /var/utmps/{u,w}tmp to avoid files with wrong owner created by busybox.