### PR TITLE
[libmarisa] 0.2.6-2: fix riscv64 build

### DIFF
--- a/0001-Fix-detection-of-MARISA_WORD_SIZE.patch
+++ b/0001-Fix-detection-of-MARISA_WORD_SIZE.patch
@@ -1,0 +1,40 @@
+From 6925413d873cec8fd4cabb360fd512be8abc4551 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 24 Apr 2024 11:17:09 +0200
+Subject: [PATCH] Fix detection of MARISA_WORD_SIZE
+
+Detect the MARISA_WORD_SIZE independent of architecture.
+
+Fixes: https://github.com/s-yata/marisa-trie/issues/40
+Fixes: https://github.com/s-yata/marisa-trie/issues/57
+Fixes: https://github.com/s-yata/marisa-trie/pull/44
+Fixes: https://github.com/s-yata/marisa-trie/pull/46
+Fixes: https://github.com/s-yata/marisa-trie/pull/56
+---
+ include/marisa/base.h | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/include/marisa/base.h b/include/marisa/base.h
+index ffcdc5b..bddce4a 100644
+--- a/include/marisa/base.h
++++ b/include/marisa/base.h
+@@ -28,14 +28,13 @@ typedef uint32_t marisa_uint32;
+ typedef uint64_t marisa_uint64;
+ #endif  // _MSC_VER
+ 
+-#if defined(_WIN64) || defined(__amd64__) || defined(__x86_64__) || \
+-    defined(__ia64__) || defined(__ppc64__) || defined(__powerpc64__) || \
+-    defined(__sparc64__) || defined(__mips64__) || defined(__aarch64__) || \
+-    defined(__s390x__)
++#if (UINTPTR_MAX == 0xffffffffffffffff)
+  #define MARISA_WORD_SIZE 64
+-#else  // defined(_WIN64), etc.
++#elif (UINTPTR_MAX == 0xffffffff)
+  #define MARISA_WORD_SIZE 32
+-#endif  // defined(_WIN64), etc.
++#else
++ #error Failed to detect MARISA_WORD_SIZE
++#endif
+ 
+ //#define MARISA_WORD_SIZE  (sizeof(void *) * 8)
+ 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=libmarisa
 pkgver=0.2.6
-pkgrel=1
+pkgrel=2
 pkgdesc='Matching Algorithm with Recursively Implemented StorAge'
 url='https://github.com/s-yata/marisa-trie'
 arch=(x86_64 aarch64 riscv64)
@@ -10,8 +10,14 @@ license=(BSD)
 depends=(musl)
 makedepends=(autoconf automake libtool)
 provides=(libmarisa.so)
-source=("https://github.com/s-yata/marisa-trie/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('1063a27c789e75afa2ee6f1716cc6a5486631dcfcb7f4d56d6485d2462e566de')
+source=("https://github.com/s-yata/marisa-trie/archive/refs/tags/v$pkgver.tar.gz"
+	"0001-Fix-detection-of-MARISA_WORD_SIZE.patch")
+sha256sums=('1063a27c789e75afa2ee6f1716cc6a5486631dcfcb7f4d56d6485d2462e566de'
+            '3df8a4e26b767a1cfde93c862c7d45d685b982d19fa4404c938258e31cba248d')
+
+prepare() {
+	_patch_ marisa-trie-$pkgver
+}
 
 build () {
 	cd marisa-trie-$pkgver


### PR DESCRIPTION
This makes detection of MARISA_WORD_SIZE architecture independent.

Links: https://github.com/s-yata/marisa-trie/pull/58