### PR TITLE
[hyprpicker] 0.3.0-1: new upstream version

### DIFF
--- a/0001-cmake-use-CXX_STANDARD-instead-of-a-flag.patch
+++ b/0001-cmake-use-CXX_STANDARD-instead-of-a-flag.patch
@@ -1,0 +1,24 @@
+From 36d974181da499369fcf3cb78792a3553fbd37ea Mon Sep 17 00:00:00 2001
+From: Vaxry <vaxry@vaxry.net>
+Date: Thu, 6 Jun 2024 11:49:13 +0200
+Subject: [PATCH] cmake: use CXX_STANDARD instead of a flag
+
+ref #74
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5010108..cd9f72b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,7 +66,8 @@ function(protocol protoPath protoName external)
+ endfunction()
+ 
+ include_directories(.)
+-add_compile_options(-std=c++23 -DWLR_USE_UNSTABLE )
++set(CMAKE_CXX_STANDARD 23)
++add_compile_options(-DWLR_USE_UNSTABLE)
+ add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith)
+ find_package(Threads REQUIRED)
+ 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=hyprpicker
-pkgver=0.2.0
+pkgver=0.3.0
 pkgrel=1
 pkgdesc="A wlroots-compatible Wayland color picker that does not suck."
 arch=(x86_64 aarch64 riscv64)
@@ -16,17 +16,26 @@ makedepends=('cmake'
              'pango'
              'wayland-protocols'
              'wlroots')
-source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
-sha256sums=('fa1b0c29682f5ede5a03d754770d152f38d869bc1faa300564680cef2de0758a')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
+	"0001-cmake-use-CXX_STANDARD-instead-of-a-flag.patch")
+sha256sums=('a443188ef7619be48c9992ea208121772b7e1da6662d672c650e30e159eeb891'
+	    '69543b77de140263ad9d45b2d3b87ddfedce64009fd9c89b64908f13a94f12bd')
+
+prepare() {
+	_patch_ "$pkgname-$pkgver"
+}
 
 build() {
-	cd "$pkgname-$pkgver"
-	make all
+	cmake -S "$pkgname-$pkgver" -B build \
+		-DCMAKE_INSTALL_PREFIX=/usr		\
+		-DCMAKE_BUILD_TYPE=Release
+	cmake --build build
 }
 
 package() {
+	DESTDIR="$pkgdir" cmake --install build
+
 	cd "$pkgname-$pkgver"
-	install -Dm755 build/hyprpicker "${pkgdir}/usr/bin/hyprpicker"
 	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/$pkgname/LICENSE"
 	install -Dm644 doc/hyprpicker.1 "${pkgdir}/usr/share/man/man1/hyprpicker.1"
 	install -Dm644 README.md "${pkgdir}/usr/share/doc/$pkgname/README.md"


### PR DESCRIPTION
Backports 36d9741 ("cmake: use CXX_STANDARD instead of a flag") to fix build with clang

Link: https://github.com/hyprwm/hyprpicker/issues/74
Link: https://github.com/hyprwm/hyprpicker/commit/36d974181da499369fcf3cb78792a3553fbd37ea