### PR TITLE
[libseccomp] 2.5.5-3: fix depends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,12 +2,13 @@
 
 pkgname=libseccomp
 pkgver=2.5.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Enhanced seccomp library'
 arch=(x86_64 aarch64 riscv64)
-license=('LGPL2.1')
+license=('LGPL-2.1-or-later')
 url="https://github.com/seccomp/libseccomp"
-makedepends=('gperf' 'linux-headers')
+depends=('linux-headers')
+makedepends=('gperf')
 source=(https://github.com/seccomp/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz)
 sha256sums=('248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375')
 


### PR DESCRIPTION
libseccomp headers depend on linux-headers.

Rerun #484 after merging.