### PR TITLE
[vala] 0.56.17-3: fix test with slibtool

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,12 +7,14 @@ pkgrel=2
 pkgdesc='Compiler for Vala'
 url='https://vala.dev'
 arch=(x86_64 aarch64 riscv64)
-license=(LGPL2)
+license=(LGPL-2.1-or-later)
 depends=(glib graphviz)
 makedepends=(gobject-introspection flex bison libxslt)
 checkdepends=(dbus)
-source=("https://download.gnome.org/sources/vala/$_ver/vala-$pkgver.tar.xz")
-sha256sums=('26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a')
+source=("https://download.gnome.org/sources/vala/$_ver/vala-$pkgver.tar.xz"
+	"fix-valadoc-ld-library-path.patch")
+sha256sums=('26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a'
+            '233af4e814b6cc9d91e605d401892d14ad3225172f596894e9aeb88ae7786581')
 
 prepare() {
 	# two checks fail
@@ -21,20 +23,22 @@ prepare() {
 	# property-array fail on obs
 	sed -i "s/objects\/property-array.vala//" \
 		vala-$pkgver/tests/Makefile.in
+
+	_patch_ vala-"$pkgver"
 }
 
 build () {
-	cd vala-$pkgver
+	cd vala-"$pkgver"
 	./configure --prefix=/usr
 	make
 }
 
 check() {
-	cd vala-$pkgver
+	cd vala-"$pkgver"
 	make check
 }
 
 package() {
-	cd vala-$pkgver
-	make install DESTDIR=$pkgdir
+	cd vala-"$pkgver"
+	make install DESTDIR="$pkgdir"
 }

--- a/fix-valadoc-ld-library-path.patch
+++ b/fix-valadoc-ld-library-path.patch
@@ -1,0 +1,10 @@
+diff --git a/valadoc/tests/libvaladoc/tests-extra-environment.sh b/valadoc/tests/libvaladoc/tests-extra-environment.sh
+index b028c33..75995f9 100644
+--- a/valadoc/tests/libvaladoc/tests-extra-environment.sh
++++ b/valadoc/tests/libvaladoc/tests-extra-environment.sh
+@@ -14,4 +14,4 @@ VALAFLAGS="\
+ 	$abs_top_srcdir/valadoc/tests/libvaladoc/parser-generic-scanner.vala \
+ "
+ export PKG_CONFIG_PATH=$abs_top_builddir:$abs_top_builddir/libvaladoc
+-export LD_LIBRARY_PATH=$abs_top_builddir/vala/.libs:$abs_top_builddir/libvaladoc/.libs
++export LD_LIBRARY_PATH=$abs_top_builddir/vala/.libs:$abs_top_builddir/libvaladoc/.libs:$abs_top_builddir/codegen/.libs


### PR DESCRIPTION
Tests of valadoc need libvalacodegen.so, which is located at codegen/.libs when building with slibtool and is not specified in valadoc/tests/libvaladoc/tests-extra-environment.sh. Fix the path pass tests.

Also use SPDX for license and some style fixes.