### PR TITLE
[eww] 0.6.0-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,26 +1,29 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=eww
-pkgver=0.5.0
-#_pkgver=0.4.0
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="A standalone widget system for wayland made in Rust"
 url='https://github.com/elkowar/eww'
 arch=(x86_64 aarch64 riscv64)
 license=(MIT)
-makedepends=(rust-nightly git)
-depends=(gtk3 gtk-layer-shell)
+makedepends=(rust git)
+depends=(gtk3 gtk-layer-shell libdbusmenu-glib libdbusmenu-gtk3)
 source=("git+$url#tag=v$pkgver")
-md5sums=('SKIP')
+sha256sums=('b750ade5e2f20f348c775374410480b7b6368d8246984f86da49067a34e21c2b')
 
-#pkgver() {
-#  cd ${pkgname}
-#  printf "$_pkgver.%s" "$(git rev-list --count HEAD)"
-#}
+prepare() {
+  cd $pkgname
+  cargo update --precise 0.3.36 time@0.3.34
+  cargo fetch --locked --target "$RUSTHOST"
+}
 
 build() {
   cd $pkgname
-  cargo build --release --package eww --no-default-features --features wayland
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release \
+    --package eww --no-default-features --features wayland
 }
 
 package() {


### PR DESCRIPTION
Switch to stable Rust toolchain and update dependency "time@0.3.34" to 0.3.36 to avoid compliation error with rustc 1.80.1.