### PR TITLE
[python-gobject] 3.50.0-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=python-gobject
-pkgver=3.48.2
-pkgrel=2
+pkgver=3.50.0
+pkgrel=1
 pkgdesc="Python bindings for GLib/GObject/GIO/GTK"
 url="https://pygobject.gnome.org/"
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -12,19 +12,23 @@ depends=(
   python
 )
 makedepends=(
-  git
   gobject-introspection
   meson
   python-cairo
   python-setuptools
 )
+checkdepends=(python-pytest)
 optdepends=('cairo: Cairo bindings')
-source=("git+https://gitlab.gnome.org/GNOME/pygobject.git#tag=$pkgver")
-sha256sums=('SKIP')
+source=("https://gitlab.gnome.org/GNOME/pygobject/-/archive/$pkgver/pygobject-$pkgver.tar.gz")
+sha256sums=('7ffce2399b25e743acf868c9eacd38800ad6fb78bf7409cee2ea87c20e5cc8ce')
 
 build() {
-  ewe-meson pygobject build
+  ewe-meson pygobject-"$pkgver" build
   meson compile -C build
+}
+
+check() {
+  meson test -C build -t 10
 }
 
 package_python-gobject() {


### PR DESCRIPTION
Enable tests and switch source to tag tarball.