### PR TITLE
[qemu] 9.1.2-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ pkgname=(qemu-common
 	 qemu-tests
 	 qemu-guest-agent
 	) # TODO: split firmwares
-pkgver=9.1.1
+pkgver=9.1.2
 pkgrel=1
 pkgdesc='A generic and open source machine emulator and virtualizer.'
 url='https://www.qemu.org/'
@@ -34,7 +34,7 @@ source=(
   "https://download.qemu.org/qemu-$pkgver.tar.xz"
   fix-strerrorname_np.patch
 )
-sha256sums=('7dc0f9da5491ff449500f3310063a36b619f236ee45706fd0846eb37d4bba889'
+sha256sums=('19fd9d7535a54d6e044e186402aa3b3b1bdfa87c392ec8884855592c8510c96f'
             '26032d49d40e63b3a92a8346353cfca416029175d7fdc3e1f8b12b7b8914707f')
 # TODO: enable (static) user targets
 
@@ -174,7 +174,6 @@ build () {
 		--enable-vhost-user-blk-server
 		--enable-vhost-vdpa
 		--enable-virtfs
-		--disable-virtfs-proxy-helper
 		--enable-vmdk
 		--enable-vnc
 		--enable-vnc-jpeg


### PR DESCRIPTION
The virtfs-proxy-helper program is removed in 9.2.0.

Link: https://github.com/qemu/qemu/commit/ed76671888676792493320db53ed773a108cbd45