### PR TITLE
[openttd] 14.1-3: fix build with Clang 19 and icu 76

### DIFF
--- a/0001-fix-compile-with-clang-19.patch
+++ b/0001-fix-compile-with-clang-19.patch
@@ -1,0 +1,15 @@
+diff --git a/src/pathfinder/yapf/yapf_road.cpp b/src/pathfinder/yapf/yapf_road.cpp
+index 41102c2..da8e519 100644
+--- a/src/pathfinder/yapf/yapf_road.cpp
++++ b/src/pathfinder/yapf/yapf_road.cpp
+@@ -462,7 +462,9 @@ public:
+ 		/* set origin (tile, trackdir) */
+ 		TileIndex src_tile = v->tile;
+ 		Trackdir src_td = v->GetVehicleTrackdir();
+-		if (!HasTrackdir(GetTrackdirBitsForRoad(src_tile, this->IsTram() ? RTT_TRAM : RTT_ROAD), src_td)) {
++		TrackFollower F(Yapf().GetVehicle());
++
++		if (!HasTrackdir(GetTrackdirBitsForRoad(src_tile, F->IsTram() ? RTT_TRAM : RTT_ROAD), src_td)) {
+ 			/* sometimes the roadveh is not on the road (it resides on non-existing track)
+ 			 * how should we handle that situation? */
+ 			return false;

--- a/0002-link-icu-components-explicitly.patch
+++ b/0002-link-icu-components-explicitly.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7eba244..94dad59 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -153,6 +153,7 @@ if(NOT OPTION_DEDICATED)
+             endif()
+             find_package(Harfbuzz)
+             find_package(ICU OPTIONAL_COMPONENTS i18n)
++            find_package(ICU OPTIONAL_COMPONENTS uc)
+         endif()
+     endif()
+ endif()
+@@ -330,6 +331,7 @@ if(NOT OPTION_DEDICATED)
+     link_package(Fontconfig TARGET Fontconfig::Fontconfig)
+     link_package(Harfbuzz TARGET harfbuzz::harfbuzz)
+     link_package(ICU_i18n)
++    link_package(ICU_uc)
+ 
+     if(SDL2_FOUND AND OPENGL_FOUND AND UNIX)
+         # SDL2 dynamically loads OpenGL if needed, so do not link to OpenGL when

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,20 +2,25 @@
 
 pkgname=openttd
 pkgver=14.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Engine for running Transport Tycoon Deluxe'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='https://www.openttd.org'
-license=(GPL)
+license=(GPL-2.0-or-later)
 depends=(fluidsynth fontconfig hicolor-icon-theme)
 makedepends=(cmake ninja)
 optdepends=('openttd-opengfx: free graphics'
             'openttd-opensfx: free soundset')
-source=("https://cdn.$pkgname.org/$pkgname-releases/$pkgver/$pkgname-$pkgver-source.tar.xz")
-sha256sums=('2c14c8f01f44148c4f2c88c169a30abcdb002eb128a92b9adb76baa76b013494')
+source=("https://cdn.$pkgname.org/$pkgname-releases/$pkgver/$pkgname-$pkgver-source.tar.xz"
+	"0001-fix-compile-with-clang-19.patch"
+	"0002-link-icu-components-explicitly.patch")
+sha256sums=('2c14c8f01f44148c4f2c88c169a30abcdb002eb128a92b9adb76baa76b013494'
+            'e98c30b4315d831751c498d19523456f3f52756527338f3d9a7184d8ce7d8ea7'
+            '0dd5e0d607aa137424a07e30c7aa6dd1332722a28947da394dbb66647129ddbd')
 
 prepare() {
   sed -i '/sse/d;/SSE/d' $pkgname-$pkgver/CMakeLists.txt
+  _patch_ "$pkgname-$pkgver"
 }
 
 build() {


### PR DESCRIPTION
Clang 19 advances the stage of member looking up for template classes with no dependent base classes, instead of delaying it to template instantiation. This breaks usage of IsTram in class CYapfFollowRoad.

ICU 76 switches to mark internal dependencies as private, which openttd used to rely on.

Link: https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics
Link: https://github.com/unicode-org/icu/commit/199bc827021ffdb43b6579d68e5eecf54c7f6f56