### PR TITLE
[firefox] 132.0.2-3: fix build with python 3.13

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -37,17 +37,22 @@ source=(
   firefox.desktop
   distribution.ini
   visibility.patch
+  fix-venv-activation.patch
+  remove-usage-of-pipes.patch
 )
 sha256sums=('329e1764f4b4e13f11dcf1fd7b3c6d8f80e512e8b7ed5bf65fbe44749c2610e9'
             '7307e32b1b553d43a3f739d5e684d9a32c45f5d7db017860c568984a420f5bb1'
             'b26bb318afbfe42325d81e1c7323541c2558bb151a647c015e72a8d50f0e9bba'
             '18a0f1df76834ac3d4ddb150aa857785df641b54f9fbf0cfb6ffcec64dad72d4'
             'a22ceb0bbf5830d3afbacd656e6893ff0ce455fae5f48c7daa5f836112291ba7'
-            '98527320399c5efe4dd0103fa0af3732470700abb515871d28e001edc3e49e7e')
+            '98527320399c5efe4dd0103fa0af3732470700abb515871d28e001edc3e49e7e'
+            '8f2d112e8e0e975174396f86ad675fd33da541130f5f1115e27a89322d361c63'
+            '9105f3fca96125c52231fc56aad63bf0826c93189392e9743414b2ee4b8db275')
 # FIXME: ADD MORE MEMORY!!!
 options=(!lto)
 
 prepare() {
+  # remove-usage-of-pipes.patch: https://hg.mozilla.org/mozilla-central/rev/7a8dbd4de3c70d6a6ac98469a9b92e4877019e0c
   _patch_ firefox-$pkgver
 
   mkdir mozbuild

--- a/fix-venv-activation.patch
+++ b/fix-venv-activation.patch
@@ -1,0 +1,12 @@
+diff --git a/python/mach/mach/site.py b/python/mach/mach/site.py
+index 7041437..ca4b8c4 100644
+--- a/python/mach/mach/site.py
++++ b/python/mach/mach/site.py
+@@ -1379,6 +1379,7 @@ def activate_virtualenv(virtualenv: PythonVirtualenv):
+         site.addsitedir(os.path.realpath(path))
+ 
+     sys.prefix = virtualenv.prefix
++    sys.exec_prefix = virtualenv.prefix
+ 
+ 
+ def _mach_virtualenv_root(checkout_scoped_state_dir):

--- a/remove-usage-of-pipes.patch
+++ b/remove-usage-of-pipes.patch
@@ -1,0 +1,49 @@
+diff --git a/python/mozbuild/mozbuild/action/node.py b/python/mozbuild/mozbuild/action/node.py
+--- a/python/mozbuild/mozbuild/action/node.py
++++ b/python/mozbuild/mozbuild/action/node.py
+@@ -1,19 +1,20 @@
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+-import pipes
+ import subprocess
+ import sys
+ 
+ import buildconfig
+ import six
+ 
++from mozbuild.shellutil import quote as shell_quote
++
+ SCRIPT_ALLOWLIST = [buildconfig.topsrcdir + "/devtools/client/shared/build/build.js"]
+ 
+ ALLOWLIST_ERROR = """
+ %s is not
+ in SCRIPT_ALLOWLIST in python/mozbuild/mozbuild/action/node.py.
+ Using NodeJS from moz.build is currently in beta, and node
+ scripts to be executed need to be added to the allowlist and
+ reviewed by a build peer so that we can get a better sense of
+@@ -42,18 +43,17 @@ def execute_node_cmd(node_cmd_list):
+ 
+     The node script is expected to output lines for all of the dependencies
+     to stdout, each prefixed by the string "dep:".  These lines will make up
+     the returned set of dependencies.  Any line not so-prefixed will simply be
+     printed to stderr instead.
+     """
+ 
+     try:
+-        printable_cmd = " ".join(pipes.quote(arg) for arg in node_cmd_list)
+-        print('Executing "{}"'.format(printable_cmd), file=sys.stderr)
++        print('Executing "{}"'.format(shell_quote(*node_cmd_list)), file=sys.stderr)
+         sys.stderr.flush()
+ 
+         # We need to redirect stderr to a pipe because
+         # https://github.com/nodejs/node/issues/14752 causes issues with make.
+         proc = subprocess.Popen(
+             node_cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+         )
+ 
+
+
+
+


### PR DESCRIPTION
Python 3.13.1 introduces behaviour change of module "sysconfig": sysconfig.get_config_vars() doesn't reflect changes of sys.prefix/ sys.exec_prefix after initialization. This breaks initialization of mach, which overwrites sys.prefix to apply a different virtualenv.

Since this has been fixed both in upstream Python and Firefox, this patch should be only considered as a temporary workaround.

Python 3.11 also removes deprecated module "pipes". Backport upstream change to fix it.

References: https://bugzilla.mozilla.org/show_bug.cgi?id=1935621
References: https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-pep594
Link: https://github.com/python/cpython/issues/126789
Link: https://hg.mozilla.org/mozilla-central/rev/7a8dbd4de3c70d6a6ac98469a9b92e4877019e0c