### PR TITLE
[sdl2-image] 2.8.3-1: new upstream version, clean up and enable features

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,25 +1,27 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=sdl2-image
-pkgver=2.8.2
-pkgrel=2
+pkgver=2.8.3
+pkgrel=1
 pkgdesc="A simple library to load images of various formats as SDL surfaces (Version 2)"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://github.com/libsdl-org/SDL_image"
 license=('MIT')
-depends=('sdl2' 'libpng' 'libtiff' 'libjpeg' 'libwebp')
+depends=('sdl2' 'libpng' 'libtiff' 'libjpeg' 'libwebp' 'libjxl' 'libavif')
 makedepends=('cmake')
 provides=(sdl2_image)
 options=(!lto)
 source=("https://github.com/libsdl-org/SDL_image/releases/download/release-${pkgver}/SDL2_image-${pkgver}.tar.gz")
-sha256sums=('8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc')
+sha256sums=('4b000f2c238ce380807ee0cb68a0ef005871691ece8646dbf4f425a582b1bb22')
+
+prepare() {
+  cd "$srcdir/SDL2_image-$pkgver"
+  autoreconf -fiv
+}
 
 build() {
-  cd "${srcdir}/SDL2_image-${pkgver}/"
-  # FIXME: add avif and jxl support
+  cd "$srcdir/SDL2_image-$pkgver"
   ./configure --disable-static --prefix=/usr \
-    --disable-avif \
-    --disable-jxl \
     --disable-avif-shared \
     --disable-jpg-shared \
     --disable-png-shared \
@@ -31,8 +33,8 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/SDL2_image-${pkgver}/"
+  cd "$srcdir/SDL2_image-$pkgver"
 
-  make DESTDIR="${pkgdir}/" install
-  install -Dm644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  make DESTDIR="$pkgdir" install
+  _install_license_ LICENSE.txt
 }


### PR DESCRIPTION
Enable avif and jxl support.