### PR TITLE
[go] 1.23.5-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(go go-doc)
 epoch=2
-pkgver=1.23.4
+pkgver=1.23.5
 pkgrel=1
 pkgdesc='Core compiler tools for the Go programming language'
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -13,8 +13,12 @@ makedepends=(go git)
 replaces=(go-pie)
 provides=(go-pie)
 options=(!strip staticlibs)
-source=("https://go.dev/dl/go${pkgver}.src.tar.gz" remove-use-gold.patch)
-sha256sums=('ad345ac421e90814293a9699cca19dd5238251c3f687980bbcae28495b263531'
+# UPSTREAM: 0001: fix test compatibility with Git 2.47.1 or higher
+source=("https://go.dev/dl/go${pkgver}.src.tar.gz"
+	"0001-cmd-go-internal-modfetch-do-not-trust-server-to.patch::https://github.com/golang/go/commit/bd80d8956f3062d2b2bff2d7da6b879dfa909f12.patch"
+	"remove-use-gold.patch")
+sha256sums=('a6f3f4bbd3e6bdd626f79b668f212fbb5649daf75084fb79b678a0ae4d97423b'
+            'd0c034795b6454652082b7e2d5dedb2150a0a6c7ae4aaef5a3bbedb78ba8962c'
             'dce8539658ba86658c20e4bc039af403e4f7a4c3ef44838fbe0e92a33a9e03ae')
 
 prepare()


### PR DESCRIPTION
Backport bd80d89 ("cmd/go/internal/modfetch: do not trust server to send all tags in shallow fetch") to fix compatibility with Git 2.48, which has stopped to send all tags in a shallow clone.

Link: https://github.com/golang/go/commit/bd80d8956f3062d2b2bff2d7da6b879dfa909f12