### PR TITLE
[hwdata] 0.392-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=hwdata
-pkgver=0.391
+pkgver=0.392
 pkgrel=1
 pkgdesc="hardware identification and configuration databases."
 url=https://github.com/vcrhonek/hwdata
-license=('GPL2')
+license=('GPL-2.0-or-later')
 arch=('any')
 source=("$url/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('620fe1c22922a3d1bd1062424e9cc6b954acea2f83b72ff0cb45144981cb1975')
+sha256sums=('1f472d8f2ec824d4efe6a75480767c4ce240fa5d91b6428d9f8775035da3ba1f')
 
 build() {
   cd $pkgname-$pkgver


### PR DESCRIPTION
This is based on the one from bot: https://github.com/eweOS/packages/pull/3071

The license has been changed to 'GPL-2.0-or-later'.