### PR TITLE
[libffi] 3.4.6-3: fix float marshalling on riscv64

### DIFF
--- a/0001-fix-float-atom-marshalling-on-clang.patch
+++ b/0001-fix-float-atom-marshalling-on-clang.patch
@@ -1,0 +1,51 @@
+The asm here results in incorrect code generation when passing
+single precision floats with Clang.
+
+Therefore, implement the storing without assembly. The D extension
+specification states:
+
+When multiple floating-point precisions are supported, then valid values of narrower n-bit types,
+n < FLEN, are represented in the lower n bits of an FLEN-bit NaN value, in a process termed
+NaN-boxing. The upper bits of a valid NaN-boxed value must be all 1s.
+
+That means we can just set the value to all ones, copy over the float
+and finally store it in an actual float type (via memcpy to avoid
+violating aliasing rules).
+
+In case of return values, we have the data loaded from the register
+into memory and we know we need just the 32 bits so simply take them.
+
+--- a/src/riscv/ffi.c
++++ b/src/riscv/ffi.c
+@@ -150,12 +150,14 @@ static void marshal_atom(call_builder *cb, int type, void *data) {
+            reinterpret floats as doubles */
+ #if ABI_FLEN >= 32
+         case FFI_TYPE_FLOAT:
+-            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(float *)data));
++            value = ~(size_t)0;
++            memcpy(&value, data, sizeof(float));
++            memcpy(&cb->aregs->fa[cb->used_float++], &value, sizeof(ABI_FLOAT));
+             return;
+ #endif
+ #if ABI_FLEN >= 64
+         case FFI_TYPE_DOUBLE:
+-            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(double *)data));
++            memcpy(&cb->aregs->fa[cb->used_float++], data, sizeof(double));
+             return;
+ #endif
+         default: FFI_ASSERT(0); break;
+@@ -173,12 +175,12 @@ static void unmarshal_atom(call_builder *cb, int type, void *data) {
+     switch (type) {
+ #if ABI_FLEN >= 32
+         case FFI_TYPE_FLOAT:
+-            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++]));
++            memcpy(data, &cb->aregs->fa[cb->used_float++], sizeof(float));
+             return;
+ #endif
+ #if ABI_FLEN >= 64
+         case FFI_TYPE_DOUBLE:
+-            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++]));
++            memcpy(data, &cb->aregs->fa[cb->used_float++], sizeof(double));
+             return;
+ #endif
+     }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libffi
 pkgname=(libffi libffi-static)
 pkgver=3.4.6
-pkgrel=2
+pkgrel=3
 pkgdesc='A portable Foregin Function Interface library.'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='http://sourceware.org/libffi/'
@@ -11,8 +11,17 @@ license=(MIT)
 depends=(musl)
 makedepends=(linux-headers)
 provides=(libffi.so)
-source=("https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz")
-sha256sums=('b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e')
+# 0001: Downstream, origin:
+# https://github.com/chimera-linux/cports/blob/fcd94a077374eb0ff4cf7096813cc2ff8319ce2e/main/libffi8/patches/riscv-fix-clang.patch
+source=("https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz"
+	"0001-fix-float-atom-marshalling-on-clang.patch")
+
+sha256sums=('b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e'
+            '7b4abcde4d75109a1066fa35bf4c8d761f6bf1b4c150d0d7264c5ee48e63d0d5')
+
+prepare() {
+  _patch_ "$pkgname-$pkgver"
+}
 
 build() {
   local configure_options=(


### PR DESCRIPTION
Chimera Linux has encountered the same problem.

Link: https://github.com/chimera-linux/cports/commit/7df9265aa4f8f62eeae352c98f5d8e4d8add9e95