### PR TITLE
[ell] 0.73-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yao Zi <ziyao@disroot.org>
 
 pkgname=ell
-pkgver=0.71
+pkgver=0.73
 pkgrel=1
 pkgdesc='Embedded Linux library'
 url='https://git.kernel.org/pub/scm/libs/ell/ell.git/about/'
@@ -11,7 +11,7 @@ depends=(musl)
 makedepends=(linux-headers git)
 provides=(libell.so)
 source=("git+https://git.kernel.org/pub/scm/libs/ell/ell.git#tag=$pkgver")
-sha256sums=('8f9a8af7a5a408ba69f0f60403e90afbe1917cc58774c6de82eeb53d77c8c5d0')
+sha256sums=('66c24cb6734be81147444fd12f2c8a440ce42ec62d2ed6ca8a1e76ab65423db4')
 
 prepare() {
 	# disable unit/test-path because of glibc-style basename()
@@ -25,6 +25,10 @@ prepare() {
 	# disable sysctl tests: may fail in container
 	sed -i "$pkgname/Makefile.am" \
 		-e 's/unit\/test-sysctl//g'
+
+	# disable hwdb tests: no udev, no hwdb.bin
+	sed -i "$pkgname/Makefile.am" \
+		-e 's/unit\/test-hwdb//g'
 
 	# disable test-uuid: many riscv64 devices lack needed kernel config
 	# https://bugs.gentoo.org/657352


### PR DESCRIPTION
Disable new unit test test-hwdb, since udev isn't available on eweOS.