### PR TITLE
[intel-media-driver] 25.2.0-1: new upstream version

### DIFF
--- a/0002-fix-compatibility-with-cmake-4.0.patch
+++ b/0002-fix-compatibility-with-cmake-4.0.patch
@@ -1,0 +1,182 @@
+From c8a2c037e25498e366467860b461b8681cea5356 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 28 Mar 2025 05:06:53 +0000
+Subject: [PATCH] [Media Common] Update cmake_minimum_required to 3.5
+ consisently across CMakeLists
+
+Some of the CMakeLists.txt are already requiring CMake 3.5.
+Update remaining files to 3.5.
+This supports the compilation with cmake-4.0.0
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ Tools/MediaDriverTools/GenDmyHex/CMakeLists.txt          | 2 +-
+ Tools/MediaDriverTools/GenKrnBin/CMakeLists.txt          | 2 +-
+ Tools/MediaDriverTools/KernelBinToSource/CMakeLists.txt  | 2 +-
+ Tools/MediaDriverTools/KrnToHex/CMakeLists.txt           | 2 +-
+ Tools/MediaDriverTools/KrnToHex_IGA/CMakeLists.txt       | 2 +-
+ cmrtlib/CMakeLists.txt                                   | 2 +-
+ cmrtlib/linux/CMakeLists.txt                             | 2 +-
+ media_driver/linux/ult/CMakeLists.txt                    | 2 +-
+ media_driver/linux/ult/libdrm_mock/CMakeLists.txt        | 2 +-
+ media_driver/linux/ult/ult_app/CMakeLists.txt            | 2 +-
+ media_driver/linux/ult/ult_app/googletest/CMakeLists.txt | 2 +-
+ os_release_info.cmake                                    | 2 +-
+ 12 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/Tools/MediaDriverTools/GenDmyHex/CMakeLists.txt b/Tools/MediaDriverTools/GenDmyHex/CMakeLists.txt
+index 2c72d282d2b..025b9354254 100644
+--- a/Tools/MediaDriverTools/GenDmyHex/CMakeLists.txt
++++ b/Tools/MediaDriverTools/GenDmyHex/CMakeLists.txt
+@@ -18,7 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ project(IntelGenDmyHexTool) 
+ add_compile_options(-std=c++11)
+ 
+diff --git a/Tools/MediaDriverTools/GenKrnBin/CMakeLists.txt b/Tools/MediaDriverTools/GenKrnBin/CMakeLists.txt
+index cc586ba766d..519ca954d33 100644
+--- a/Tools/MediaDriverTools/GenKrnBin/CMakeLists.txt
++++ b/Tools/MediaDriverTools/GenKrnBin/CMakeLists.txt
+@@ -18,7 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(GenKrnBin)
+ 
+diff --git a/Tools/MediaDriverTools/KernelBinToSource/CMakeLists.txt b/Tools/MediaDriverTools/KernelBinToSource/CMakeLists.txt
+index 713d08600ec..91eacf15d8b 100644
+--- a/Tools/MediaDriverTools/KernelBinToSource/CMakeLists.txt
++++ b/Tools/MediaDriverTools/KernelBinToSource/CMakeLists.txt
+@@ -18,7 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ project(IntelKernelBinToSourceTool) 
+ add_compile_options(-std=c++11)
+ 
+diff --git a/Tools/MediaDriverTools/KrnToHex/CMakeLists.txt b/Tools/MediaDriverTools/KrnToHex/CMakeLists.txt
+index a3cb7341c6e..e2bfde5e884 100644
+--- a/Tools/MediaDriverTools/KrnToHex/CMakeLists.txt
++++ b/Tools/MediaDriverTools/KrnToHex/CMakeLists.txt
+@@ -18,7 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ project(KrnToHexTool) 
+ add_compile_options(-std=c++11)
+ 
+diff --git a/Tools/MediaDriverTools/KrnToHex_IGA/CMakeLists.txt b/Tools/MediaDriverTools/KrnToHex_IGA/CMakeLists.txt
+index af622be19cb..40e4eba171e 100644
+--- a/Tools/MediaDriverTools/KrnToHex_IGA/CMakeLists.txt
++++ b/Tools/MediaDriverTools/KrnToHex_IGA/CMakeLists.txt
+@@ -18,7 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(KrnToHex_IGA)
+ 
+diff --git a/cmrtlib/CMakeLists.txt b/cmrtlib/CMakeLists.txt
+index 9ecb1e4e10a..54f907b3772 100644
+--- a/cmrtlib/CMakeLists.txt
++++ b/cmrtlib/CMakeLists.txt
+@@ -19,7 +19,7 @@
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+ set(BUILD_ALL $ENV{BUILD_ALL})
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ project(CM_RT)
+ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/linux)
+ 
+diff --git a/cmrtlib/linux/CMakeLists.txt b/cmrtlib/linux/CMakeLists.txt
+index b066138d9df..df02bab2a69 100644
+--- a/cmrtlib/linux/CMakeLists.txt
++++ b/cmrtlib/linux/CMakeLists.txt
+@@ -18,7 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ include (${CMAKE_CURRENT_LIST_DIR}/cmrt_utils.cmake)
+ 
+ 
+diff --git a/media_driver/linux/ult/CMakeLists.txt b/media_driver/linux/ult/CMakeLists.txt
+index 9fb5b39ee42..f06b490110b 100644
+--- a/media_driver/linux/ult/CMakeLists.txt
++++ b/media_driver/linux/ult/CMakeLists.txt
+@@ -17,7 +17,7 @@
+ # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ 
+ if ("${BUILD_TYPE}" STREQUAL "debug")
+     set(CMAKE_BUILD_TYPE "Debug")
+diff --git a/media_driver/linux/ult/libdrm_mock/CMakeLists.txt b/media_driver/linux/ult/libdrm_mock/CMakeLists.txt
+index 438715a91c3..e5d2c88ed5b 100644
+--- a/media_driver/linux/ult/libdrm_mock/CMakeLists.txt
++++ b/media_driver/linux/ult/libdrm_mock/CMakeLists.txt
+@@ -17,7 +17,7 @@
+ # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(libdrm_mock)
+ 
+diff --git a/media_driver/linux/ult/ult_app/CMakeLists.txt b/media_driver/linux/ult/ult_app/CMakeLists.txt
+index 1b24fed7fc5..64217b9fe65 100644
+--- a/media_driver/linux/ult/ult_app/CMakeLists.txt
++++ b/media_driver/linux/ult/ult_app/CMakeLists.txt
+@@ -17,7 +17,7 @@
+ # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(devult)
+ 
+diff --git a/media_driver/linux/ult/ult_app/googletest/CMakeLists.txt b/media_driver/linux/ult/ult_app/googletest/CMakeLists.txt
+index 6b1f7433596..bba044a97d8 100644
+--- a/media_driver/linux/ult/ult_app/googletest/CMakeLists.txt
++++ b/media_driver/linux/ult/ult_app/googletest/CMakeLists.txt
+@@ -17,7 +17,7 @@
+ # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(devult)
+ 
+diff --git a/os_release_info.cmake b/os_release_info.cmake
+index b4a84e2c5cb..a3b879d8545 100644
+--- a/os_release_info.cmake
++++ b/os_release_info.cmake
+@@ -29,7 +29,7 @@ set(_os_release_info TRUE)
+ # of the local cmake environment.
+ 
+ # Set cmake policies for at least this level:
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.5)
+ 
+ 
+ # Function get_os_release_info - Determine and return OS name and version

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yao Zi <ziyao@disroot.org>
 
 pkgname=intel-media-driver
-pkgver=25.1.4
+pkgver=25.2.0
 pkgrel=1
 pkgdesc='Intel Media Driver for VAAPI'
 url='https://github.com/intel/media-driver/'
@@ -10,10 +10,15 @@ arch=(x86_64)
 license=(BSD-3-Clause MIT)
 depends=(musl libva intel-gmmlib)
 makedepends=(cmake linux-headers)
+# 0001: Downstream, silent Clang warnings about usage of VLA, which is common
+#	in intel-media-driver
+# 0002: Under review, fix compatibility with CMake 4.0
 source=("https://github.com/intel/media-driver/archive/refs/tags/intel-media-$pkgver.tar.gz"
-	"0001-silence-clang-cxx-vla-extension.patch")
-sha256sums=('6339bba3168102f5a608f447076c9efb2a8194e847a9dac219fbc13324192a76'
-            '5daa5c7716935c7133e2e9beffff7d635571fa1efbca5b888b8c01f9bff3ddba')
+	"0001-silence-clang-cxx-vla-extension.patch"
+	"0002-fix-compatibility-with-cmake-4.0.patch::https://github.com/intel/media-driver/pull/1919.patch")
+sha256sums=('be7a1aa9341c637a6adb26164adffeffcad859980246fab4df04f3d7d8e2114b'
+            '5daa5c7716935c7133e2e9beffff7d635571fa1efbca5b888b8c01f9bff3ddba'
+            '03dfeb072533b20e79bdff83e38f6f729010c771e7896955c83c4dc0e35b8b83')
 _dirname="media-driver-intel-media-$pkgver"
 
 prepare() {


### PR DESCRIPTION
Apply an under-review patch to fix compatibility with CMake 4.0.

Reference: https://github.com/intel/media-driver/issues/1918
Link: https://github.com/intel/media-driver/pull/1919