### PR TITLE
[shaderc] 2025.2-1: new upstream version

### DIFF
--- a/0001-Do-not-link-to-stub-libSPIRV.so.patch
+++ b/0001-Do-not-link-to-stub-libSPIRV.so.patch
@@ -1,0 +1,52 @@
+From 1a38ebcd66548d174feb6ae856194b1ae46cd68e Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Fri, 25 Apr 2025 10:59:20 +0000
+Subject: [PATCH] Do not link to stub libSPIRV.so
+
+---
+ glslc/CMakeLists.txt           | 2 +-
+ libshaderc/CMakeLists.txt      | 1 -
+ libshaderc_util/CMakeLists.txt | 2 +-
+ 3 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/glslc/CMakeLists.txt b/glslc/CMakeLists.txt
+index e431761b127d..48715fb73deb 100644
+--- a/glslc/CMakeLists.txt
++++ b/glslc/CMakeLists.txt
+@@ -43,7 +43,7 @@ if (SHADERC_ENABLE_WGSL_OUTPUT)
+ endif(SHADERC_ENABLE_WGSL_OUTPUT)
+ 
+ target_link_libraries(glslc PRIVATE
+-  glslang SPIRV    # Glslang libraries
++  glslang    # Glslang libraries
+   $<$<BOOL:${SHADERC_ENABLE_WGSL_OUTPUT}>:libtint>      # Tint libraries, optional
+   shaderc_util shaderc                                  # internal Shaderc libraries
+   ${CMAKE_THREAD_LIBS_INIT})
+diff --git a/libshaderc/CMakeLists.txt b/libshaderc/CMakeLists.txt
+index df9a88d079dc..0b9902326e90 100644
+--- a/libshaderc/CMakeLists.txt
++++ b/libshaderc/CMakeLists.txt
+@@ -65,7 +65,6 @@ find_package(Threads)
+ set(SHADERC_LIBS
+   glslang ${CMAKE_THREAD_LIBS_INIT}
+   shaderc_util
+-  SPIRV # from glslang
+   SPIRV-Tools
+ )
+ 
+diff --git a/libshaderc_util/CMakeLists.txt b/libshaderc_util/CMakeLists.txt
+index 69ba519a9bff..df41cafa7f22 100644
+--- a/libshaderc_util/CMakeLists.txt
++++ b/libshaderc_util/CMakeLists.txt
+@@ -46,7 +46,7 @@ add_definitions(-DENABLE_HLSL)
+ 
+ find_package(Threads)
+ target_link_libraries(shaderc_util PRIVATE
+-  glslang SPIRV
++  glslang
+   SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
+ 
+ shaderc_add_tests(
+-- 
+2.49.0
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=shaderc
-pkgver=2024.4
+pkgver=2025.2
 pkgrel=1
 pkgdesc='Collection of tools, libraries and tests for shader compilation'
 url='https://github.com/google/shaderc'
@@ -10,8 +10,12 @@ license=('Apache')
 provides=('libshaderc_shared.so')
 depends=('glslang' 'spirv-tools')
 makedepends=('cmake' 'ninja' 'python' 'spirv-headers')
-source=(https://github.com/google/shaderc/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz)
-sha512sums=('d313af65e76664640020c964cbd7021e3b6f12ea839a58ef67f6052d9af684fc7fd237a687737e6483f24b89d5c85b3e0c0fafeec66b3646f77031cb0d6c9587')
+# 0001: Downstream fix (should be upstreamed), glslang 15.2.0 (although
+# accidentally) dropped the libSPIRV.so stub.
+source=(https://github.com/google/shaderc/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
+	0001-Do-not-link-to-stub-libSPIRV.so.patch)
+sha512sums=('6761372591075944fddd926e9f7c2ea9447496566d2d549f523c6c529c3bd753d459b66d499f76d955bdcfb335016daddbeba49b087f4ecabf37d76a46ac14cd'
+            'b1fbdeadf3f75626297f70c59de37b86eaef9fdfb54b99b6be68d6581900a45d93ea6fc50183e82a037783fdc6a8433c09191e69271b7f6d98b15f0ff2aeb8a6')
 
 prepare() {
   cd ${pkgname}-${pkgver}
@@ -27,6 +31,8 @@ EOF
 
   # fix missing PYTHON_EXECUTABLE
   sed -i 's@${PYTHON_EXECUTABLE}@python@' glslc/test/CMakeLists.txt
+
+  _patch_ ${pkgname}-${pkgver}
 }
 
 build() {


### PR DESCRIPTION
Apply a downstream fix to remove dependency to libSPIRV.so.

Reference: https://github.com/KhronosGroup/glslang/issues/3882