### PR TITLE
[llvm] 20.1.4-2: Temporarily move compiler-rt to LLVM_ENABLE_PROJECTS

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=(llvm llvm-tools llvm-devel llvm-libs llvm-lto lldb openmp lld clang fla
 _realpkgname=llvm-project
 pkgver=20.1.4
 _binutilsver=2.44
-pkgrel=1
+pkgrel=2
 arch=('x86_64' 'aarch64' 'riscv64' 'loongarch64')
 url='https://llvm.org'
 license=('custom:Apache 2.0 with LLVM Exception')
@@ -276,8 +276,8 @@ build()
 
   cmake -B build -G Ninja \
     "${CMARGS[@]}" \
-    -DLLVM_ENABLE_PROJECTS="clang;flang;mlir;lld;lldb;openmp" \
-    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libunwind;libcxxabi;libcxx" \
+    -DLLVM_ENABLE_PROJECTS="compiler-rt;clang;flang;mlir;lld;lldb;openmp" \
+    -DLLVM_ENABLE_RUNTIMES="libunwind;libcxxabi;libcxx" \
     -S $_basedir/llvm
 
   # Ensure compiler-rt has been available before building other rt libraries


### PR DESCRIPTION
Previously compiler-rt was enabled through LLVM_ENABLE_PROJECTS, which seems to affect the ABI (compiler-rt symbols aren't correctly hidden). Let's temporarily restore the configuration to restore the ABI.