### PR TITLE
[libarchive] 3.7.9-2: Disable libxml2 to simplify dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,11 +2,11 @@
 
 pkgname=libarchive
 pkgver=3.7.9
-pkgrel=1
+pkgrel=2
 pkgdesc='Multi-format archive and compression library'
 url='https://libarchive.org/'
 arch=(x86_64 aarch64 riscv64 loongarch64)
-license=('BSD')
+license=('BSD-2-Clause')
 depends=('acl' 'openssl' 'xz' 'zlib' 'libxml2' 'libbz2' 'zstd')
 source=("https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.xz")
 sha256sums=('ed8b5732e4cd6e30fae909fb945cad8ff9cb7be5c6cdaa3944ec96e4a200c04c')
@@ -14,7 +14,12 @@ sha256sums=('ed8b5732e4cd6e30fae909fb945cad8ff9cb7be5c6cdaa3944ec96e4a200c04c')
 build()
 {
   cd "${pkgname}-${pkgver}"
-  ./configure --prefix=/usr --disable-static
+  # Disable libxml2 to simplify dependency graph of our base and base-devel
+  # This disables XAR support.
+  ./configure --prefix=/usr \
+  	--disable-static		\
+	--without-xml2			\
+	--without-expat
   make
 }
 


### PR DESCRIPTION
libarchive makes use of libxml2 for XAR format support, which isn't a critical feature. This is one step towards removing libxml2 from our dependency graph of base and base-devel.

Reference: https://github.com/eweOS/packages/issues/3939