### PR TITLE
[libtg_owt] r20250424.f2f3c5f-2: Fix compatibility with LLVM 20

### DIFF
--- a/0001-Remove-ABSL_ATTRIBUTE_LIFETIME_BOUND-from-void-funct.patch
+++ b/0001-Remove-ABSL_ATTRIBUTE_LIFETIME_BOUND-from-void-funct.patch
@@ -1,0 +1,29 @@
+From c6ffc8aefb8520a51234c380cc415dd21469cf6b Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Mon, 12 May 2025 09:05:30 +0000
+Subject: [PATCH] Remove ABSL_ATTRIBUTE_LIFETIME_BOUND from void functions
+
+LLVM 20 errors on void functions whose parameters are applied
+[[lifetimebound]].
+
+Link: https://github.com/llvm/llvm-project/pull/113460
+---
+ src/api/candidate.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/api/candidate.h b/src/api/candidate.h
+index 0aa75aa..715761a 100644
+--- a/src/api/candidate.h
++++ b/src/api/candidate.h
+@@ -105,7 +105,7 @@ class RTC_EXPORT Candidate {
+   // cricket::LOCAL_PORT_TYPE). The type should really be an enum rather than a
+   // string, but until we make that change the lifetime attribute helps us lock
+   // things down. See also the `Port` class.
+-  void set_type(absl::string_view type ABSL_ATTRIBUTE_LIFETIME_BOUND) {
++  void set_type(absl::string_view type) {
+     Assign(type_, type);
+   }
+ 
+-- 
+2.49.0
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@ _commit=f2f3c5f65a1163cb6c05c636a0fca54cf9355d19
 _libyuv_commit=ec6f15079ff373b7651698a68bba7244b3556981
 _crc32c_commit=02e65f4fd3065d27b2e29324800ca6d04df16126
 pkgver=r20250424.${_commit:0:7}
-pkgrel=1
+pkgrel=2
 pkgdesc="Telegram's fork of WebRTC"
 url='https://github.com/desktop-app/tg_owt'
 arch=(x86_64 aarch64)
@@ -13,14 +13,19 @@ license=(BSD-3-Clause)
 depends=(abseil-cpp ffmpeg libjpeg openssl openh264 libopus libpipewire libvpx
 	 libsrtp)
 makedepends=(cmake git yasm linux-headers python)
+# use-libopengl.patch: Should be upstreamed, search for libOpenGL instead of
+#		       libGL to build without GLX.
+# 0001: Downstream, fix LLVM 20 build
 source=("$url/archive/$_commit.tar.gz"
 	"git+https://gitlab.com/chromiumsrc/libyuv.git#commit=$_libyuv_commit"
 	"https://github.com/google/crc32c/archive/$_crc32c_commit.tar.gz"
-	"use-libopengl.patch")
+	"use-libopengl.patch"
+	"0001-Remove-ABSL_ATTRIBUTE_LIFETIME_BOUND-from-void-funct.patch")
 sha256sums=('66ac4e82e76a79329ae29e4efde3787c1ba28c794311f6109ea09f7b93b8eaf7'
             '8e42db1f3e308c3baefc7c2c1368f29af12650f75305b4a2e2c0ea6fa00d21bc'
             '50ac512ad20ebca0be21bcf7c3c6d15aa3fcc27550b09825fab061bffe512bdf'
-            'f49cfdb50f5ca0cd7692a43287fd8396e59eeb438a509cce8afd3438736d136b')
+            'f49cfdb50f5ca0cd7692a43287fd8396e59eeb438a509cce8afd3438736d136b'
+            'e55689c8225319bf66dd630f005544e982351b08877a5bff150c9b646dc995af')
 
 prepare() {
 	_patch_ tg_owt-$_commit


### PR DESCRIPTION
LLVM 20 starts to emit errors on void functions whose parameters are applied with [[lifetimebound]]. Let's simply remove the modifier from affected sites.

Reference: https://github.com/llvm/llvm-project/pull/113460
Link: https://github.com/desktop-app/tg_owt/issues/150