### PR TITLE
[mesa] 25.1.0-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,16 +3,17 @@
 pkgbase='mesa'
 pkgname=(
   mesa
-  opencl-clover-mesa
-  vulkan-swrast
-  vulkan-virtio
+  opencl-mesa
+  vulkan-gfxstream
   vulkan-intel
   vulkan-radeon
+  vulkan-swrast
+  vulkan-virtio
   vulkan-mesa-layers
 )
 pkgdesc="An open-source implementation of the OpenGL specification"
-pkgver=25.0.4
-pkgrel=2
+pkgver=25.1.0
+pkgrel=1
 arch=(x86_64 aarch64 riscv64 loongarch64)
 depends=('libglvnd' 'libelf' 'zstd' 'libdrm' 'llvm' 'spirv-tools')
 makedepends=(
@@ -21,27 +22,39 @@ makedepends=(
   'meson'
   'wayland' 'wayland-protocols'
   'python-packaging'
+  'libpng'
   'llvm-devel'
   'linux-headers'
-  'libclc' 'spirv-llvm-translator' 'spirv-tools'
+  'directx-headers'
+  'libclc' 'rust' 'rust-bindgen' 'spirv-llvm-translator' 'spirv-tools'
   'python-mako' 'python-pycparser' 'python-yaml')
 url="https://www.mesa3d.org/"
 license=('custom')
 # mold may fails with lto enabled
 options=(!lto)
-source=(https://mesa.freedesktop.org/archive/$pkgbase-$pkgver.tar.xz)
-sha512sums=('562a97bd0374ff2a76f71c848df4fe542f1fc66c420a9101eb4bb1947d00eee4417d9c6f2d1be19638663753785c19384f8a6dc078c3187448ab79413d906152')
+source=(
+  https://mesa.freedesktop.org/archive/$pkgbase-$pkgver.tar.xz
+  gfxstream-lfs64.patch
+)
+sha512sums=('40298370727fa1ad6d59be8692dfef01c42e41780816e9b951a05f779c7acca127162d2d3cedfccb7bfe3834b9e917c2b9bc6cb76887488d919cb61741a1da1a'
+            'bcb3389a8382ccec65e2f476f43db5eab45d47b66869644ebb489472281f99a9d0cc24f54803bf1eef2eb03993b3f83fb50d303c36858e6c07600fff3f2aca51')
 
+[ "$CARCH" = x86_64 ] && pkgname+=(vulkan-dzn)
 [ "$CARCH" = aarch64 ] && pkgname+=(vulkan-panfrost)
+
+prepare()
+{
+  _patch_ $pkgbase-$pkgver
+}
 
 build()
 {
   GALLIUM_DRI_COMMON="r300,r600,radeonsi,nouveau,virgl,svga,softpipe,llvmpipe,zink"
-  VULKAN_DRI_COMMON="amd,intel,intel_hasvk,swrast,virtio"
+  VULKAN_DRI_COMMON="amd,gfxstream,intel,intel_hasvk,swrast,virtio"
   case "${CARCH}" in
     x86_64)
-	    GALLIUM_DRI="${GALLIUM_DRI_COMMON},i915,iris,crocus"
-	    VULKAN_DRI="${VULKAN_DRI_COMMON}"
+	    GALLIUM_DRI="${GALLIUM_DRI_COMMON},i915,iris,crocus,d3d12"
+	    VULKAN_DRI="${VULKAN_DRI_COMMON},microsoft-experimental"
 	    ;;
     aarch64)
 	    GALLIUM_DRI="${GALLIUM_DRI_COMMON},panfrost,freedreno,lima,etnaviv"
@@ -56,7 +69,7 @@ build()
 	    VULKAN_DRI="${VULKAN_DRI_COMMON}"
 	    ;;
   esac
-  VULKAN_LAYER=device-select,intel-nullhw,overlay
+  VULKAN_LAYER=device-select,intel-nullhw,overlay,screenshot,vram-report-limit
   ewe-meson $pkgbase-$pkgver build \
     --libdir=lib \
     -D platforms=wayland \
@@ -67,11 +80,11 @@ build()
     -Dgles1=enabled \
     -Dgles2=enabled \
     -Dopengl=true \
-    -Dosmesa=true \
     -Dvulkan-drivers=${VULKAN_DRI} \
     -Dvulkan-layers=${VULKAN_LAYER} \
     -Dgallium-drivers=${GALLIUM_DRI} \
     -Dgallium-extra-hud=true \
+    -Dgallium-rusticl=true \
     -Dgallium-vdpau=disabled \
     -Dvideo-codecs=all \
     -Dmicrosoft-clc=disabled \
@@ -82,7 +95,6 @@ build()
     -Dlmsensors=disabled \
     -Ddefault_library=shared \
     -Dllvm-orcjit=true \
-    -Dgallium-opencl=icd \
     -Dintel-rt=disabled
 
   meson configure build
@@ -102,10 +114,19 @@ package_mesa()
 
   cd $pkgdir
 
-  # opencl-clover-mesa
-  _pick_ opencl-clover-mesa usr/lib/gallium-pipe
-  _pick_ opencl-clover-mesa usr/lib/libMesaOpenCL*
-  _pick_ opencl-clover-mesa etc/OpenCL/vendors/mesa.icd
+  # opencl-mesa
+  _pick_ opencl-mesa usr/lib/libRusticlOpenCL*
+  _pick_ opencl-mesa etc/OpenCL/vendors/rusticl.icd
+
+  # vulkan-dzn
+  _pick_ vulkan-dzn usr/share/vulkan/icd.d/dzn_icd.*.json
+  _pick_ vulkan-dzn usr/lib/libvulkan_dzn.so
+  _pick_ vulkan-dzn usr/lib/libspirv_to_dxil.*
+  _pick_ vulkan-dzn usr/bin/spirv2dxil
+
+  # vulkan-gfxstream
+  _pick_ vulkan-gfxstream usr/share/vulkan/icd.d/gfxstream_vk_icd.*.json
+  _pick_ vulkan-gfxstream usr/lib/libvulkan_gfxstream.so
 
   # vulkan-swrast
   _pick_ vulkan-swrast usr/share/vulkan/icd.d/lvp_icd*.json
@@ -138,8 +159,8 @@ package_mesa()
     -t "$pkgdir/usr/share/licenses/$pkgname"
 }
 
-package_opencl-clover-mesa() {
-  pkgdesc="Open-source OpenCL drivers - Clover variant"
+package_opencl-mesa() {
+  pkgdesc="Open-source OpenCL drivers"
   depends=(
     clang
     expat
@@ -151,6 +172,8 @@ package_opencl-clover-mesa() {
   )
   optdepends=("opencl-headers: headers necessary for OpenCL development")
   provides=('opencl-driver')
+  replaces=("opencl-clover-mesa")
+  conflicts=("opencl-clover-mesa")
   mv "$srcdir/pkgs/$pkgname/"{etc,usr} "${pkgdir}/"
 
   install -Dm644 $srcdir/$pkgbase-$pkgver/docs/license.rst \
@@ -159,6 +182,30 @@ package_opencl-clover-mesa() {
 
 _vulkan_driver_deps=('expat' 'libdrm' 'llvm' 'vulkan-icd-loader' 'wayland'
 		     'zlib' 'zstd' 'spirv-tools')
+
+package_vulkan-dzn()
+{
+  pkgdesc="Open-source Vulkan driver for D3D12"
+  depends=(${_vulkan_driver_deps[*]})
+  optdepends=("vulkan-mesa-layers: additional vulkan layers")
+  provides=(vulkan-driver)
+  mv "$srcdir/pkgs/$pkgname/usr" "${pkgdir}/usr"
+
+  install -Dm644 $srcdir/$pkgbase-$pkgver/docs/license.rst \
+    -t "$pkgdir/usr/share/licenses/$pkgname"
+}
+
+package_vulkan-gfxstream()
+{
+  pkgdesc="Open-source Vulkan driver for Graphics Streaming Kit"
+  depends=(${_vulkan_driver_deps[*]})
+  optdepends=('vulkan-mesa-layers: additional vulkan layers')
+  provides=('vulkan-driver')
+  mv "$srcdir/pkgs/$pkgname/usr" "${pkgdir}/usr"
+
+  install -Dm644 $srcdir/$pkgbase-$pkgver/docs/license.rst \
+    -t "$pkgdir/usr/share/licenses/$pkgname"
+}
 
 package_vulkan-swrast()
 {
@@ -223,7 +270,7 @@ package_vulkan-panfrost()
 package_vulkan-mesa-layers()
 {
   pkgdesc="Mesa's Vulkan layers"
-  depends=('libdrm' 'wayland' 'python')
+  depends=('libdrm' 'libpng' 'wayland' 'python')
 
   mv "$srcdir/pkgs/$pkgname/usr" "${pkgdir}/usr"
 

--- a/gfxstream-lfs64.patch
+++ b/gfxstream-lfs64.patch
@@ -1,0 +1,15 @@
+--- a/src/gfxstream/guest/platform/linux/LinuxVirtGpuBlob.cpp
++++ b/src/gfxstream/guest/platform/linux/LinuxVirtGpuBlob.cpp.new
+@@ -97,10 +97,10 @@
+     }
+ 
+     uint8_t* ptr = static_cast<uint8_t*>(
+-        mmap64(nullptr, mSize, PROT_WRITE | PROT_READ, MAP_SHARED, mDeviceHandle, map.offset));
++        mmap(nullptr, mSize, PROT_WRITE | PROT_READ, MAP_SHARED, mDeviceHandle, map.offset));
+ 
+     if (ptr == MAP_FAILED) {
+-        mesa_loge("mmap64 failed with (%s)", strerror(errno));
++        mesa_loge("mmap failed with (%s)", strerror(errno));
+         return nullptr;
+     }
+ 


### PR DESCRIPTION
recheck after `rust-bindgen` and `directx-headers` published

- osmesa is removed
- opencl-clover is removed
- opencl-rusticl is added and become the only opencl driver (`opencl-mesa`)
- `dzn`(only in x86_64) and `gfxstream` vulkan driver are added