### PR TITLE
[libarchive] 3.7.9-3: Remove libxml2 from depends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=libarchive
 pkgver=3.7.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Multi-format archive and compression library'
 url='https://libarchive.org/'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 license=('BSD-2-Clause')
-depends=('acl' 'openssl' 'xz' 'zlib' 'libxml2' 'libbz2' 'zstd')
+depends=('acl' 'openssl' 'xz' 'zlib' 'libbz2' 'zstd')
 source=("https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.xz")
 sha256sums=('ed8b5732e4cd6e30fae909fb945cad8ff9cb7be5c6cdaa3944ec96e4a200c04c')
 


### PR DESCRIPTION
We've disabled the dependency but sadly forgot to remove it from depends.