### PR TITLE
[rust-analyzer] 2025.06.09-2: add rust-analyzer-proc-macro-srv

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=rust-analyzer
 pkgver=2025.06.09
 _pkgver=${pkgver//./-}
-pkgrel=1
+pkgrel=2
 pkgdesc='Rust compiler front-end for IDEs'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='https://rust-analyzer.github.io'
@@ -30,7 +30,7 @@ check() {
 
 package() {
   cd $pkgname-$_pkgver
-  install -Dt "$pkgdir"/usr/bin target/release/$pkgname
+  install -Dt "$pkgdir"/usr/bin target/release/$pkgname{,-proc-macro-srv}
   _install_license_ LICENSE-MIT{,}
   _install_license_ LICENSE-APACHE{,}
 }


### PR DESCRIPTION
rust-analyzer's proc-macro functions need it to work.