### PR TITLE
[rust] 1.87.0-2: remove rls, add rust-analyzer-proc-macro-srv, provide rustdoc

### DIFF
--- a/0004-bootstrap-Change-libexec-dir.patch
+++ b/0004-bootstrap-Change-libexec-dir.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 6 May 2021 20:14:58 +0200
+Subject: [PATCH] bootstrap: Change libexec dir
+
+---
+ src/bootstrap/src/core/build_steps/dist.rs | 2 +-
+ src/bootstrap/src/core/build_steps/tool.rs | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/bootstrap/src/core/build_steps/dist.rs b/src/bootstrap/src/core/build_steps/dist.rs
+index 83f71aeed720..2922054d6d60 100644
+--- a/src/bootstrap/src/core/build_steps/dist.rs
++++ b/src/bootstrap/src/core/build_steps/dist.rs
+@@ -432,7 +432,7 @@ fn prepare_image(builder: &Builder<'_>, compiler: Compiler, image: &Path) {
+                 },
+                 builder.kind,
+             ) {
+-                let dst = image.join("libexec");
++                let dst = image.join("lib");
+                 builder.install(&ra_proc_macro_srv.tool_path, &dst, FileType::Executable);
+             }
+ 
+diff --git a/src/bootstrap/src/core/build_steps/tool.rs b/src/bootstrap/src/core/build_steps/tool.rs
+index cd57e06ae04a..05d117eba66e 100644
+--- a/src/bootstrap/src/core/build_steps/tool.rs
++++ b/src/bootstrap/src/core/build_steps/tool.rs
+@@ -954,7 +954,7 @@ fn run(self, builder: &Builder<'_>) -> Option<ToolBuildResult> {
+ 
+         // Copy `rust-analyzer-proc-macro-srv` to `<sysroot>/libexec/`
+         // so that r-a can use it.
+-        let libexec_path = builder.sysroot(self.compiler).join("libexec");
++        let libexec_path = builder.sysroot(self.compiler).join("lib");
+         t!(fs::create_dir_all(&libexec_path));
+         builder.copy_link(
+             &tool_result.tool_path,

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=rust
 pkgname=(rust rust-src)
 pkgver=1.87.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Systems programming language focused on safety, speed and concurrency"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='https://www.rust-lang.org/'
@@ -15,12 +15,14 @@ source=(https://static.rust-lang.org/dist/rustc-$pkgver-src.tar.gz
         config.toml.tpl
         0001-musl-static.patch
         0002-disable-no-default-libraries.patch
-        0003-drop-latomic-for-riscv-targets.patch)
+        0003-drop-latomic-for-riscv-targets.patch
+        0004-bootstrap-Change-libexec-dir.patch)  # install rust-analyzer-proc-macro-srv in /usr/lib rather than /usr/libexec
 sha256sums=('149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76'
-            'd5879bb6d754707d75791c2c7fd80aeeffbac3e0ac8d79495b2cb5edb2a368b2'
+            '97703a9e3c3277647dfc8e2081b05aa95bff0765ab44b4182d8ff0db35fd9e65'
             '35a15feca59b93afd27590ba91b657c0ac2ef21d9da8e3d6eb9bc7f04bad29f0'
             'f9340dde4ba5ed44b21f36de3605994fc32fbeaf24234a1036b162c1ee94b58d'
-            '6d4a08f1512d065e7b131a30cecb8f8c9c801e55d6dec824b12b7024bf2c6a56')
+            '6d4a08f1512d065e7b131a30cecb8f8c9c801e55d6dec824b12b7024bf2c6a56'
+            '6eb382aa4e6bccfffecd46dac95019994e1d82e031db054407c58a5c6438442c')
 
 prepare() {
   _patch_ rustc-$pkgver-src
@@ -42,7 +44,7 @@ build() {
 }
 
 package_rust() {
-  provides=(cargo rustfmt)
+  provides=(cargo rustfmt rustdoc)
   cp -r "$srcdir"/install/* "$pkgdir"
 
   rm "$pkgdir"/usr/lib/rustlib/{components,install.log,rust-installer-version,uninstall.sh}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,63 +7,51 @@ pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='https://www.rust-lang.org/'
-license=(MIT Apache)
+license=('MIT OR Apache-2.0')
 options=(!lto)
-source=(
-  https://static.rust-lang.org/dist/rustc-$pkgver-src.tar.gz
-  config.toml.tpl
-  0001-musl-static.patch
-  0002-disable-no-default-libraries.patch
-  0003-drop-latomic-for-riscv-targets.patch
-)
+depends=(musl llvm-libs musl-static curl libssh2 openssl)
+makedepends=(rust llvm-devel libffi perl python cmake ninja)
+source=(https://static.rust-lang.org/dist/rustc-$pkgver-src.tar.gz
+        config.toml.tpl
+        0001-musl-static.patch
+        0002-disable-no-default-libraries.patch
+        0003-drop-latomic-for-riscv-targets.patch)
 sha256sums=('149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76'
             'd5879bb6d754707d75791c2c7fd80aeeffbac3e0ac8d79495b2cb5edb2a368b2'
             '35a15feca59b93afd27590ba91b657c0ac2ef21d9da8e3d6eb9bc7f04bad29f0'
             'f9340dde4ba5ed44b21f36de3605994fc32fbeaf24234a1036b162c1ee94b58d'
             '6d4a08f1512d065e7b131a30cecb8f8c9c801e55d6dec824b12b7024bf2c6a56')
 
-depends=(musl llvm-libs musl-static curl libssh2 openssl)
-makedepends=(rust llvm-devel libffi perl python cmake ninja)
-
-prepare()
-{
-  _patch_ ${pkgbase}c-$pkgver-src
+prepare() {
+  _patch_ rustc-$pkgver-src
 }
 
-build()
-{
-  sed -i "s@%RUSTVER%@$pkgver@g" config.toml.tpl
-  case $CARCH in
-    riscv64)
-      sed -i "s@%RUSTTARGET%@riscv64gc-unknown-linux-musl@g" config.toml.tpl
-      ;;
-    *)
-      sed -i "s@%RUSTTARGET%@${CARCH}-unknown-linux-musl@g" config.toml.tpl
-      ;;
-  esac
-  cp config.toml.tpl ${pkgbase}c-$pkgver-src/config.toml
+build() {
+  sed config.toml.tpl \
+    -e "s@%RUSTVER%@$pkgver@g" \
+    -e "s@%RUSTTARGET%@$RUSTHOST@g" \
+    > rustc-$pkgver-src/config.toml
 
   export RUST_BACKTRACE=1
 
-  cd $srcdir/${pkgbase}c-${pkgver}-src
-  DESTDIR="$srcdir/install" python ./x.py install -j "$(nproc)"
+  cd "$srcdir"/rustc-$pkgver-src
+  DESTDIR="$srcdir"/install python ./x.py install -j "$(nproc)"
 
-  cd $srcdir/install
+  cd "$srcdir"/install
   _pick_ rust-src usr/lib/rustlib/src
 }
 
-package_rust()
-{
+package_rust() {
   provides=(cargo rustfmt)
-  cp -r $srcdir/install/* "$pkgdir"
+  cp -r "$srcdir"/install/* "$pkgdir"
 
-  rm $pkgdir/usr/lib/rustlib/{components,install.log,rust-installer-version,uninstall.sh}
-  rm $pkgdir/usr/lib/rustlib/manifest-*
+  rm "$pkgdir"/usr/lib/rustlib/{components,install.log,rust-installer-version,uninstall.sh}
+  rm "$pkgdir"/usr/lib/rustlib/manifest-*
 
-  install -d $pkgdir/usr/share/bash-completion
-  install -d $pkgdir/usr/share/licenses/rust
+  install -d "$pkgdir"/usr/share/bash-completion
+  install -d "$pkgdir"/usr/share/licenses/rust
 
-  mv -t $pkgdir/usr/share/licenses/rust $pkgdir/usr/share/doc/rustc/COPYRIGHT*
+  mv -t "$pkgdir"/usr/share/licenses/rust "$pkgdir"/usr/share/doc/rustc/COPYRIGHT*
 }
 
 package_rust-src() {

--- a/config.toml.tpl
+++ b/config.toml.tpl
@@ -14,7 +14,16 @@ rustc = "/usr/bin/rustc"
 rustfmt = "/usr/bin/rustfmt"
 locked-deps = true
 vendor = true
-tools = ["cargo", "rls", "clippy", "rustfmt", "rustdoc", "analysis", "src", "rust-demangler"]
+tools = [
+  "cargo",
+  "clippy",
+  "rustfmt",
+  "rustdoc",
+  "analysis",
+  "src",
+  "rust-demangler",
+  "rust-analyzer-proc-macro-srv",
+]
 sanitizers = false
 profiler = true
 # Generating docs fails with the wasm32-* targets


### PR DESCRIPTION
rust-analyzer-proc-macro-srv is required for rust-analyzer. It is shipped along with rust package because it strongly depends on current rustc version. rls is deprecated in favor of rust-analyzer.

Also includes a PKGBUILD style fix commit.