### PR TITLE
[linux] 6.15.4-2: Add pahole to depends of linux-devel

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=(linux linux-headers linux-devel linux-docs)
 _basename=linux
 pkgver=6.15.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux kernel'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='http://www.kernel.org'
@@ -106,6 +106,8 @@ package_linux-headers() {
 
 package_linux-devel() {
   pkgdesc="Headers and scripts for building modules for the $pkgdesc"
+  # Required if BTF is enabled
+  depends=(pahole)
 
   cd "$_basename-$pkgver"
   local _builddir="$pkgdir/usr/src/$pkgbase"


### PR DESCRIPTION
Pahole is required when building out-of-tree modules if BTF is enabled when building the image.

Issue: https://github.com/eweOS/packages/issues/4493