### PR TITLE
[linux-lts] 6.12.35-2: Add pahole to depends of linux-devel

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=linux-lts
 pkgname=(linux-lts linux-lts-headers linux-lts-devel linux-lts-docs)
 _basename=linux
 pkgver=6.12.35
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux LTS kernel'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='http://www.kernel.org'
@@ -109,6 +109,8 @@ package_linux-lts-headers() {
 
 package_linux-lts-devel() {
   pkgdesc="Headers and scripts for building modules for the $pkgdesc"
+  # Required if BTF is enabled
+  depends=(pahole)
 
   cd "$_basename-$pkgver"
   local _builddir="$pkgdir/usr/src/$pkgbase"


### PR DESCRIPTION
Pahole is required when building out-of-tree modules if BTF is enabled when building the image.

Issue: https://github.com/eweOS/packages/issues/4493