### PR TITLE
[frei0r-plugins] 2.3.3-3: Rebuild against OpenCV 4.12.0

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=frei0r-plugins
 pkgver=2.3.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Collection of video effect plugins'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='https://frei0r.dyne.org/'
@@ -21,6 +21,12 @@ optdepends=(
 )
 source=("git+https://github.com/dyne/frei0r#tag=v$pkgver")
 sha256sums=('8d0f2e8386ff070eaccc6764e4240b8da7cc67ea2899a73e94e11a5c5f21944c')
+
+prepare() {
+  cd frei0r
+  # Backport, fix CMake 4.0 compatibility
+  git cherry-pick -n 31efba74b26c161125c6c41d381dcf3f6207a728
+}
 
 build() {
   cmake -S frei0r -B build -G Ninja \


### PR DESCRIPTION
Also backport a commit to fix compatibility with CMake 4.0.