### PR TITLE
[pipewire] 1.4.7-2: Fix screen casting

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   gst-plugin-pipewire
 )
 pkgver=1.4.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Low-latency audio/video router and processor"
 url="https://pipewire.org"
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -14,6 +14,7 @@ license=(MIT)
 makedepends=(
   'alsa-lib'
   'dbus'
+  'ffmpeg'
   'glib'
   'gstreamer-devel'
   'libebur128'
@@ -63,7 +64,6 @@ build()
     -D jack=disabled
     -D v4l2=disabled
     -D libcamera=disabled
-    -D videoconvert=disabled
     -D videotestsrc=disabled
     -D volume=disabled
     -D sdl2=disabled
@@ -108,6 +108,7 @@ package_pipewire()
     "libpipewire=$epoch:$pkgver-$pkgrel"
     'alsa-lib'
     'dbus'
+    'ffmpeg'
     'glib'
     'libebur128'
     'libpulse'


### PR DESCRIPTION
With Pipewire 1.4.0 or later, videoadapter is enabled for all video streams, regardless of whether videoadapter is built through videoconvert build-time option.

This may cause silent screen-share failures without any useful log, but only xdg-desktop-portal-wlr hangs with a connection never turned to "streaming" state".

Let's simply enable the option.

Link: https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/4819