### PR TITLE
[sdl2-compat] 2.32.56-2: Enable -ffat-lto-objects

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=sdl2-compat
 pkgver=2.32.56
-pkgrel=1
+pkgrel=2
 pkgdesc="An SDL2 compatibility layer that uses SDL3 behind the scenes"
 url="https://github.com/libsdl-org/sdl2-compat"
 depends=('musl' 'sdl3')
@@ -25,6 +25,10 @@ prepare() {
 }
 
 build() {
+  # sdl2-compat contains static libraries, thus we should enable
+  # -ffat-lto-objects to ensure linking works even without -flto supplied at
+  # linktime.
+  check_option lto y && export CFLAGS="$CFLAGS -ffat-lto-objects"
   cmake -S sdl2-compat-$pkgver \
     -B build -G Ninja \
     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
sdl2-compat contains misc static libraries (*.a), which are LLVM IR objects that cannot be linked by mold on architectures enabling LTO.

This commit enables the -ffat-lto-objects options to ensure users may link their own programs to these static libraries even without LTO enabled.