### PR TITLE
[pacman] 7.0.0-12: Lower ISA baseline to la64v1.0 for loongarch64

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 pkgbase=pacman
 pkgname=(libalpm pacman repo-tools)
 pkgver=7.0.0
-pkgrel=11
+pkgrel=12
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url=https://www.archlinux.org/pacman/
 license=(GPL)
@@ -83,7 +83,7 @@ build() {
     x86_64) makepkg_cflags+=" -fno-plt -march=x86-64 -fstack-clash-protection -fcf-protection" ;;
     aarch64) makepkg_cflags+=" -fno-plt -march=armv8-a" ;;
     riscv64) makepkg_cflags+=" -march=rv64gc" ;;
-    loongarch64) makepkg_cflags+=" -march=la464" ;;
+    loongarch64) makepkg_cflags+=" -march=la64v1.0" ;;
   esac
   case $CARCH in
     riscv64) makepkg_rustarch="riscv64gc" ;;


### PR DESCRIPTION
LoongArch defines some common ISA profiles, like la64v1.0 and la64v1.1. Desktop devices should support at least la64v1.0.

At the time that eweOS starts loongarch64 port, LLVM doesn't support such representation. Instead, we hardcode -march=la464 in CFLAGS. This actually raises the baseline to la64v1.1, above the least desktop baseline for LoongArch devices.

Now we have upgraded LLVM to version 20, and Loongson is also going to release low-end desktop devices without LASX thus below la64v1.1 profile. Let's switch to -march=la64v1.0 in CFLAGS to support these devices as well.

Note to completely support these devices, rebuilding the world is necessary. This will be done gradually in the future since the baseline problem isn't urgent.

Link: https://github.com/eweOS/packages/issues/4726