### PR TITLE
[python] 3.15.5-4: Don't create pip as a symlink to pip3

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=python
 pkgname=(python python-tests)
 pkgver=3.13.5
-pkgrel=3
+pkgrel=4
 _pybasever=${pkgver%.*}
 pkgdesc='The Python programming language'
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -89,7 +89,6 @@ package_python()
   ln -s idle3                 "${pkgdir}"/usr/bin/idle
   ln -s pydoc3                "${pkgdir}"/usr/bin/pydoc
   ln -s python${_pybasever}.1 "${pkgdir}"/usr/share/man/man1/python.1
-  ln -s pip3                  "${pkgdir}"/usr/bin/pip
 
   # some useful "stuff" FS#46146
   install -dm755 "${pkgdir}"/usr/lib/python${_pybasever}/Tools/{i18n,scripts}


### PR DESCRIPTION
This is now a job of python-pip.