### PR TITLE
[readline] 8.3-2: fix segfault in display.c with a workaround

### DIFF
--- a/0000-8.3.0-display-null-prompt-workaround.patch
+++ b/0000-8.3.0-display-null-prompt-workaround.patch
@@ -1,0 +1,15 @@
+*** ../readline-8.3/display.c	Fri May  2 09:20:32 2025
+--- readline-8.3/display.c	Sun Jul  6 17:16:28 2025
+***************
+*** 784,788 ****
+  /* Useful shorthand used by rl_redisplay, update_line, rl_move_cursor_relative */
+  #define INVIS_FIRST()	(local_prompt_invis_chars[0])
+! #define WRAP_OFFSET(line, offset)  ((line <= prompt_last_screen_line) ? local_prompt_invis_chars[line] : 0)
+  
+  #define W_OFFSET(line, offset) ((line) == 0 ? offset : 0)
+--- 784,788 ----
+  /* Useful shorthand used by rl_redisplay, update_line, rl_move_cursor_relative */
+  #define INVIS_FIRST()	(local_prompt_invis_chars[0])
+! #define WRAP_OFFSET(line, offset)  ((line <= prompt_last_screen_line && local_prompt_invis_chars) ? local_prompt_invis_chars[line] : 0)
+  
+  #define W_OFFSET(line, offset) ((line) == 0 ? offset : 0)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=readline
 pkgver=8.3
-pkgrel=1
+pkgrel=2
 pkgdesc='GNU readline library'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 license=('GPL')
@@ -12,13 +12,22 @@ provides=('libhistory.so' 'libreadline.so')
 
 PURGE_TARGETS+=(usr/share/info/* usr/share/readline/*)
 
+# 0000-8.3.0-display-null-prompt-workaround.patch is from
+# https://gitlab.archlinux.org/archlinux/packaging/packages/readline/-/commit/b30636dc66fc783a091af51b049dc5240f861dd0
 source=(
   "http://ftp.gnu.org/gnu/readline/readline-${pkgver}.tar.gz"
   inputrc
+  0000-8.3.0-display-null-prompt-workaround.patch
 )
 
 sha256sums=('fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc'
-            '36e9611f935ee108d161587b0615f9c390192ef4bbff6dc59b58671261029901')
+            '36e9611f935ee108d161587b0615f9c390192ef4bbff6dc59b58671261029901'
+            '9e7c483c6482dd441d89edeb9534d078f843130ef0ff2c98da7a75a06cd0e319')
+
+prepare()
+{
+  _patch_ $pkgname-$pkgver
+}
 
 build()
 {


### PR DESCRIPTION
Imported the patch from https://gitlab.archlinux.org/archlinux/packaging/packages/readline/-/commit/b30636dc66fc783a091af51b049dc5240f861dd0