### PR TITLE
[linux-uapi-headers] 6.16.7-1: init package

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Yukari Chiba <i@0x7f.cc>
+# Contributor: Eric Long <i@hack3r.moe>
+
+pkgname=linux-uapi-headers
+_basename=linux
+pkgver=6.16.7
+pkgrel=1
+pkgdesc='Linux syscall API headers for userspace usage'
+arch=(x86_64 aarch64 riscv64 loongarch64)
+url='http://www.kernel.org'
+license=('GPL-2.0-only with Linux-syscall-note')
+makedepends=(rsync)
+options=(!strip)
+provides=(linux-headers)
+replaces=(linux-headers)
+conflicts=(linux-headers)
+source=("https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$pkgver.tar.xz")
+sha256sums=('5be3daa1f9427b1bdb34c4894d9c1adfac38cff674376fe0611a3065729a1a81')
+
+case $CARCH in
+x86_64)
+  _build_arch=x86_64
+  _dev_arch=x86
+  ;;
+aarch64)
+  _build_arch=arm64
+  _dev_arch=arm64
+  ;;
+riscv64)
+  _build_arch=riscv
+  _dev_arch=riscv
+  ;;
+loongarch64)
+  _build_arch=loongarch
+  _dev_arch=loongarch
+  ;;
+esac
+
+package() {
+  pkgdesc="Kernel headers sanitized for use in userspace"
+
+  cd "$_basename-$pkgver"
+  make LLVM=1 LLVM_IAS=1 ARCH=$_build_arch INSTALL_HDR_PATH="$pkgdir/usr" headers_install
+}


### PR DESCRIPTION
This allows us to build Linux Userspace API headers separately from Linux kernel image.

Link: https://github.com/eweOS/packages/issues/5535