### PR TITLE
[dinit-services] 20251013.1-1: new upstream version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=dinit-services
 pkgname=dinit-services
-pkgver=20250903.1
+pkgver=20251015.1
 pkgrel=1
 pkgdesc='Service monitoring / "init" system (service files)'
 url='https://github.com/eweOS/dinit-services'
@@ -15,7 +15,7 @@ license=(Apache)
 options=(emptydirs)
 makedepends=(git)
 depends=(dinit)
-sha256sums=('a199409e7ce82770698a88bfe6d81c5bae600ca90e0716e92507ebfca9ca6fd7'
+sha256sums=('ff8d3df100c6dbdd29d64a4a865d4216dcea216f755b906531717524f4b91a71'
             '6d6e651bce957f8be540aaa84e5b5185610244fa0bc5b5945ad281be6cc9f2d0')
 
 package()


### PR DESCRIPTION
Fixes necessary modules failing to load when modalias for a file misses the newline before EOF