### PR TITLE
[libxkbcommon] 1.12.1-1: new upstream version

### DIFF
--- a/0001-compose-No-fallback-if-no-missing-locale-detection.patch
+++ b/0001-compose-No-fallback-if-no-missing-locale-detection.patch
@@ -1,0 +1,64 @@
+From 76085bd159a21cd2ede8633f96740250908349b4 Mon Sep 17 00:00:00 2001
+From: Pierre Le Marre <dev@wismill.eu>
+Date: Mon, 20 Oct 2025 13:07:58 +0200
+Subject: [PATCH] compose: No fallback if no missing locale detection
+
+Do not use `newlocale()` if it accepts missing locales. It happens with
+muslc, while glibc works as expected.
+
+It fixes the incorrect behavior of the fallback introduced in
+135b3204a15838205c97e793cd41faa742d429e2.
+---
+ changes/api/+879.bugfix.md            |  1 +
+ include/xkbcommon/xkbcommon-compose.h |  3 ++-
+ meson.build                           | 15 ++++++++++++++-
+ 3 files changed, 17 insertions(+), 2 deletions(-)
+ create mode 100644 changes/api/+879.bugfix.md
+
+diff --git a/changes/api/+879.bugfix.md b/changes/api/+879.bugfix.md
+new file mode 100644
+index 000000000..a98928ea3
+--- /dev/null
++++ b/changes/api/+879.bugfix.md
+@@ -0,0 +1 @@
++compose: Fixed some C standard libraries such as musl not detecting missing locales.
+diff --git a/include/xkbcommon/xkbcommon-compose.h b/include/xkbcommon/xkbcommon-compose.h
+index 585f28c96..375a683f3 100644
+--- a/include/xkbcommon/xkbcommon-compose.h
++++ b/include/xkbcommon/xkbcommon-compose.h
+@@ -197,7 +197,8 @@ enum xkb_compose_format {
+  *    preconfigured directory.
+  *
+  * Since 1.12, system locales not registered in `$XLOCALEDIR` will fallback
+- * to `en_US.UTF-8`.
++ * to `en_US.UTF-8`, if missing locale detection is supported by the C standard
++ * library in use.
+  *
+  * @param context
+  *     The library context in which to create the compose table.
+diff --git a/meson.build b/meson.build
+index 150bbd5f2..c711753b9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -172,7 +172,20 @@ if not cc.has_header_symbol('limits.h', 'PATH_MAX', prefix: system_ext_define)
+     endif
+ endif
+ if cc.has_header_symbol('locale.h', 'newlocale', prefix: system_ext_define)
+-    configh_data.set('HAVE_NEWLOCALE', 1)
++    # Use newlocale only if it fails on missing locales
++    r = cc.run(
++        '''
++        #define _GNU_SOURCE
++        #include <locale.h>
++        int main(void){
++            locale_t loc = newlocale(LC_ALL_MASK, "¡NONSENSE!", (locale_t) 0);
++            return (loc != (locale_t) 0);
++        }''',
++        name: 'newlocale fails on invalid locales',
++    )
++    if r.compiled() and r.returncode() == 0
++        configh_data.set('HAVE_NEWLOCALE', 1)
++    endif
+ endif
+ 
+ # Silence some security & deprecation warnings on MSVC

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -25,13 +25,11 @@ source=("https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-$
 sha256sums=('bb1543d956a5b962ee414174e9882c5d6fac3af9f95ebf48defb105151780ed1'
             '5474fe234a693389dd341f1bf55459af43d592b394253324eaec5ca83f651387')
 
-prepare()
-{
+prepare() {
   _patch_ libxkbcommon-xkbcommon-${pkgver}
 }
 
-build()
-{
+build() {
   ewe-meson libxkbcommon-xkbcommon-${pkgver} build \
     -Denable-x11=false \
     -Denable-docs=false
@@ -50,8 +48,7 @@ check() {
   meson test -C build --print-errorlogs
 }
 
-package()
-{
+package() {
   meson install -C build --destdir "$pkgdir"
   install -Dt "$pkgdir/usr/share/licenses/$pkgname" \
     -m644 libxkbcommon-xkbcommon-${pkgver}/LICENSE

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yukari Chiba <i@0x7f.cc>
 
 pkgname=libxkbcommon
-pkgver=1.11.0
+pkgver=1.12.1
 pkgrel=1
 pkgdesc='Keymap handling library for toolkits and window systems'
 url='https://xkbcommon.org/'
@@ -17,8 +17,18 @@ makedepends=(
 provides=(libxkbcommon.so libxkbregistry.so)
 depends=(libxml2 xkeyboard-config)
 checkdepends=(weston)
-source=("https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-${pkgver}.tar.gz")
-sha256sums=('78a6b14f16e9a55025978c252e53ce9e16a02bfdb929550b9a0db5af87db7e02')
+# 0001: Under review, fix test failures on musl where newlocale() doesn't
+#	complain about invalid locales.
+#	https://github.com/xkbcommon/libxkbcommon/pull/880
+source=("https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-${pkgver}.tar.gz"
+	"0001-compose-No-fallback-if-no-missing-locale-detection.patch")
+sha256sums=('bb1543d956a5b962ee414174e9882c5d6fac3af9f95ebf48defb105151780ed1'
+            '5474fe234a693389dd341f1bf55459af43d592b394253324eaec5ca83f651387')
+
+prepare()
+{
+  _patch_ libxkbcommon-xkbcommon-${pkgver}
+}
 
 build()
 {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,8 @@ pkgrel=1
 pkgdesc='Keymap handling library for toolkits and window systems'
 url='https://xkbcommon.org/'
 arch=(x86_64 aarch64 riscv64 loongarch64)
-license=(custom)
+license=(MIT MIT-open-group HPND HPND-sell-variant X11
+	 LicenseRef-digital-equipment-corporation)
 makedepends=(
   libxml2
   meson


### PR DESCRIPTION
Apply under-review patch to fix testsuite failure on musl system, where newlocale() doesn't complain about invalid/nonexistent locales but always succeeds.

Link: https://github.com/xkbcommon/libxkbcommon/issues/879
Link: https://github.com/xkbcommon/libxkbcommon/pull/880