### PR TITLE
[mimalloc] 2.2.4-2: Enable MI_NO_OPT_ARCH

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mimalloc
 pkgver=2.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="General-purpose allocator with excellent performance characteristics"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://github.com/microsoft/mimalloc"
@@ -20,7 +20,8 @@ build()
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DMI_BUILD_STATIC=OFF \
     -DMI_BUILD_OBJECT=OFF \
-    -DMI_INSTALL_TOPLEVEL=ON
+    -DMI_INSTALL_TOPLEVEL=ON \
+    -DMI_NO_OPT_ARCH=ON
   cmake --build build
 }
 


### PR DESCRIPTION
Or on AArch64, atomic operations specified in LSE extension will raise the baseline to armv8.1a.

Link: https://github.com/microsoft/mimalloc/commit/069279e3e7f6424eed1ea79f129ab26b22195b55