### PR TITLE
[librsvg] 2.61.3-1: Explicitly enable gdk-pixbuf loader

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -41,8 +41,11 @@ prepare() {
 }
 
 build() {
+  # Enable the pixbuf loader until SVG-capable glycin loader is enabled in
+  # gdk-pixbuf. See https://gitlab.gnome.org/GNOME/librsvg/-/issues/1186
   local meson_options=(
     -D avif=enabled
+    -D pixbuf-loader=enabled
   )
 
   export LDFLAGS="$LDFLAGS -lunwind"


### PR DESCRIPTION
Since librsvg 2.61.2, as gdk-pixbuf prefers glycin instead of librsvg-vendored SVG loader, librsvg disables build of the gdk-pixbuf loader by default. However on eweOS, we don't have glycin enabled for now, so it seems just better to keep the option enabled.

Link: https://gitlab.gnome.org/GNOME/librsvg/-/issues/1186