### PR TITLE
[ncurses] 6.5-4: Remove unnecessary build source

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ncurses
 pkgver=6.5
-pkgrel=3
+pkgrel=4
 arch=(x86_64 aarch64 riscv64 loongarch64)
 license=(MIT-open-group)
 pkgdesc="System V Release 4.0 curses emulation library"
@@ -14,12 +14,8 @@ provides=(
   libpanelw.so
   libncursesw.so
 )
-source=(
-  "http://ftp.gnu.org/gnu/ncurses/ncurses-${pkgver}.tar.gz"
-  https://invisible-mirror.net/archives/ncurses/current/termcap.src.gz
-)
-sha256sums=('136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6'
-            'e53ce12919e351d46ccd0a8a6ac595764d5bfe9b688b74830a522a3959f3b02d')
+source=("http://ftp.gnu.org/gnu/ncurses/ncurses-${pkgver}.tar.gz")
+sha256sums=('136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6')
 
 build()
 {


### PR DESCRIPTION
termcap.src.gz isn't used anywhere, let's remove it.