### PR TITLE
[ifupdown-ng] 0.12.1-5: Migrate to new dinit syntax

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ifupdown-ng
 pkgver=0.12.1
-pkgrel=4
+pkgrel=5
 pkgdesc='Flexible ifup/ifdown implementation'
 url='https://github.com/ifupdown-ng/ifupdown-ng'
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -13,7 +13,7 @@ options=(!lto emptydirs)
 source=("https://github.com/ifupdown-ng/ifupdown-ng/archive/refs/tags/ifupdown-ng-$pkgver.tar.gz"
 	"ifupdown-ng.service")
 sha256sums=('d42c8c18222efbce0087b92a14ea206de4e865d5c9dde6c0864dcbb2b45f2d85'
-	    '16c871d2a46787344fea5b06e8e5c1d6d80f17e418629ffe2ffa5d442bbab62b')
+            '3e3321263a2214bb365aeabef6e06865a461a98b2b19a11884bd69b64e507b03')
 
 # TODO: enable checks (need Kyua)
 

--- a/ifupdown-ng.service
+++ b/ifupdown-ng.service
@@ -1,5 +1,5 @@
 type = scripted
 command = /usr/sbin/ifup -a
 restart = false
-depends-on = rc.target
-before = network.target
+depends-on: rc.target
+before: network.target


### PR DESCRIPTION
Link: https://github.com/eweOS/packages/issues/6141