### PR TITLE
[luanti] 5.14.0-2: Migrate to new dinit syntax

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('luanti' 'luanti-server' 'luanti-common')
 pkgver=5.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc='An open source voxel game-creation platform with easy modding and game creation'
 url='https://www.minetest.net/'
 arch=(x86_64 aarch64)	# limited by LuaJIT
@@ -21,7 +21,7 @@ source=(
   luanti.tmpfiles
 )
 sha256sums=('b9f561fa37db3c7ea1b8ba15cfede8282b7a79b9e939b0357269c8b037cf5aea'
-            '8ca438d65bc4557d9ab6e16752d55fe41582c2aedd0fcbdd97effa5fd114601c'
+            '9082fb94d3c480e13c7a1fc5bb0d6ef8421cc537b86916877a98c32e2af0e8d3'
             '294283b0686c4d73d816168544ab2f813a7a0ca63fc49da59563a329dd329eed'
             'c9a0c78a49461f56381e5615045d036cd594b741c910129eccf43e475c40cca1')
 

--- a/luanti.service
+++ b/luanti.service
@@ -1,5 +1,5 @@
 type = process
 command = /usr/bin/luantiserver --config /etc/luanti/$1.conf --map-dir /var/lib/luanti/$1/
 restart = false
-depends-on = network.target
+depends-on: network.target
 run-as = luanti


### PR DESCRIPTION
Link: https://github.com/eweOS/packages/issues/6141