### PR TITLE
[pipewire] 1.4.9-2: Migrate to new dinit syntax

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   gst-plugin-pipewire
 )
 pkgver=1.4.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Low-latency audio/video router and processor"
 url="https://pipewire.org"
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -39,8 +39,8 @@ source=(
   pipewire.conf.in
 )
 sha256sums=('8066a7b220069e4c6e3b02bd2b6ea303bba66df255023c07c99323449ba8fe3c'
-            'cb26aa54e55c83cb4e842aaba1b1778393285836fa6cff3daf9a37ebcefc822a'
-            '640863de03ce75f14b2fb97622f7e398b55889dbf65d9022ea9fdad652ab593d'
+            'b2b7f7730f1607fccb59248dd48da3eed577afc35feef24faac0193de5832191'
+            '2a0807319f60671483de2e015427241d8f9224ccce2616eff143377c0a840193'
             'a1d7812aabba038ff1d90a0af2139f0c420419c5f66ee401b9bc45d0445edfdd')
 
 prepare()

--- a/pipewire-pulse.user.service
+++ b/pipewire-pulse.user.service
@@ -1,4 +1,4 @@
 type               = process
 command            = /usr/bin/pipewire-pulse
-depends-on         = pipewire
+depends-on: pipewire
 

--- a/pipewire.user.service
+++ b/pipewire.user.service
@@ -1,4 +1,3 @@
 type               = process
 command            = /usr/bin/pipewire
-depends-on         = dbus
-
+depends-on: dbus


### PR DESCRIPTION
Link: https://github.com/eweOS/packages/issues/6141