### PR TITLE
[wireplumber] 0.5.12-2: Migrate to new dinit service syntax

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   libwireplumber
 )
 pkgver=0.5.12
-pkgrel=1
+pkgrel=2
 pkgdesc="Session / policy manager implementation for PipeWire"
 url="https://pipewire.pages.freedesktop.org/wireplumber/"
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -27,7 +27,7 @@ source=(
   fix-enum.patch
 )
 sha256sums=('0ce5cd48087bc5b559d7e1a947e9e0adb2a9b6f1dabd984af801f30fbba5e19c'
-            '808beac207616837f1b6d005cb28f7f017333f8b742a74c8343386b6ed6f96e4'
+            '019fac03a27fef4f51d79cf6a390766dc91f0050a77e7b80c0d823c4921ec732'
             '02b051ad202a14d6e6f5fd53144731f668b44debb5cd86af4b249597135ff3a6')
 
 prepare() {

--- a/wireplumber.user.service
+++ b/wireplumber.user.service
@@ -1,5 +1,5 @@
 type = process
 command = /usr/bin/wireplumber
 log-type = buffer
-depends-on = pipewire
+depends-on: pipewire
 smooth-recovery = true


### PR DESCRIPTION
Link: https://github.com/eweOS/packages/issues/6141