### PR TITLE
[wpa_supplicant] 2.11-5: Migrate to new dinit service syntax

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=wpa_supplicant
 pkgver=2.11
-pkgrel=4
+pkgrel=5
 pkgdesc='A utility providing key negotiation for WPA wireless networks'
 url='https://w1.fi/wpa_supplicant/'
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -16,7 +16,7 @@ source=(
 )
 sha256sums=('912ea06f74e30a8e36fbb68064d6cdff218d8d591db0fc5d75dee6c81ac7fc0a'
             'c22c3998f9bb0cae019435dcb0e85dcb5ddd2922a70eff17b797aacd48a4f011'
-            '50e95487fa481e637c56a19a82f181b4887c285b3df0c81b9dccb2b0ce939274')
+            '14f1776e6073789a5798a3480a70a67da532c7ead17eb7bbca30d1be288f65dd')
 
 prepare()
 {

--- a/wpa_supplicant.service
+++ b/wpa_supplicant.service
@@ -1,6 +1,6 @@
 type = process
 command = /usr/bin/wpa_supplicant -u
 restart = false
-depends-on = rc.target
-depends-on = dbus
-before = network.target
+depends-on: rc.target
+depends-on: dbus
+before: network.target


### PR DESCRIPTION
Link: https://github.com/eweOS/packages/issues/6141