### PR TITLE
[pyalpm] 0.10.12-2: depends on libalpm instead of pacman, rebuild aga…

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=pyalpm
 pkgver=0.10.12
-pkgrel=1
+pkgrel=2
 pkgdesc="Python 3 bindings for libalpm"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://gitlab.archlinux.org/archlinux/pyalpm"
 license=('GPL-3.0-or-later')
-depends=('python' 'pacman')
+depends=('python' 'libalpm')
 makedepends=('git' 'python-setuptools' 'python-pkgconfig' 'python-build' 'python-installer' 'python-wheel')
 checkdepends=('python-pytest' 'python-pytest-pacman')
 source=("git+https://gitlab.archlinux.org/archlinux/pyalpm.git#tag=$pkgver")


### PR DESCRIPTION
…inst pacman 7.1.0