### PR TITLE
[busybox] 1.37.0-14: Set DRI render nodes as 0666

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=busybox
 pkgver=1.37.0
-pkgrel=13
+pkgrel=14
 pkgdesc="Utilities for rescue and embedded systems"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://www.busybox.net"
@@ -47,7 +47,7 @@ sha256sums=('3311dff32e746499f4df0d5df04d7eb396382d7e108bb9250e7b519b837043a4'
             '63044f1031a3d9405fbd23df091d4816264141241fd74730acd0b6b294b87618'
             '69e028725a63763e21684fb0ce941f6a34a4b72bb328a0cab43b4d39d6d767dc'
             '802aff2664c40867a616144cfa2c5cd0c28e53d6a07f8d78bdcdf78705244842'
-            '9c6d96a3e0d044d0ebb39e00bcad0eceb98001146c807eea98b0685076ed1945'
+            'd18b00837d3316037ae1f58f29c04fe84d6caf115b1e54f0485e08890bf5f4e1'
             '6ebc1362e00c59005ccb70ccb663e7efcd7efb1606a7b1255d972f3585fbf901'
             '622d0a1743a127bab1fc15e5057034db52c7fa475298b8d085cfc7c046ae5537'
             'cd62d9d1ae294099b1a28e6ffb053267dd7a17ba8cfadb810bb7901292c4f89b'

--- a/mdev.conf
+++ b/mdev.conf
@@ -90,5 +90,6 @@ SUBSYSTEM=block;.* root:disk 660 */usr/bin/mdev-helper-storage-device
 -SUBSYSTEM=net;DEVPATH=.*/net/.*;.*     root:root 600 @/usr/bin/mdev-helper-settle-nics --write-mactab
 
 # libudev-zero helper
-SUBSYSTEM=drm;.*   root:video 660 */usr/bin/libudev-helper
+SUBSYSTEM=drm;dri/renderD([0-9]+) root:render 666 */usr/bin/libudev-helper
+SUBSYSTEM=drm;dri/.* root:video 660 */usr/bin/libudev-helper
 SUBSYSTEM=input;.* root:input 660 */usr/bin/libudev-helper


### PR DESCRIPTION
Render devices should be accessible for all processes, differing from KMS ones.