### PR TITLE
[atuin] 18.10.0-2: remove vendored libsqlite3

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=atuin
 pkgver=18.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Magical shell history"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://atuin.sh"
 license=(MIT)
-depends=(musl llvm-libs)
+depends=(musl llvm-libs sqlite)
 makedepends=(rust)
 optdepends=('blesh: bash integration')
 source=("https://github.com/atuinsh/atuin/archive/v$pkgver/atuin-$pkgver.tar.gz")
@@ -20,7 +20,7 @@ prepare() {
 
 build() {
   cd $pkgname-$pkgver
-  cargo build --release --frozen --all-features
+  LIBSQLITE3_SYS_USE_PKG_CONFIG=1 cargo build --release --frozen --all-features
   mkdir completions/
   for sh in bash fish zsh; do
     target/release/$pkgname gen-completions -s $sh -o completions/
@@ -31,7 +31,7 @@ check() {
   cd $pkgname-$pkgver
   # skipping atuin sync tests in binary crates, as atuin sync is an online
   # feature whose test requires complicated server deployment
-  cargo test --frozen --all-features --lib
+  LIBSQLITE3_SYS_USE_PKG_CONFIG=1 cargo test --frozen --all-features --lib
 }
 
 package() {


### PR DESCRIPTION
Link against the system-provided `libsqlite3` instead of the bundled copy.

According to the [Gentoo bug report](https://bugs.gentoo.org/959120), a major performance regression occurs when Atuin is built against the system-provided SQLite with ICU enabled.
    
Since the `sqlite` package in eweOS repository is built with ICU disabled, this issue cannot be reproduced on eweOS.
    
Atuin upstream issue: https://github.com/atuinsh/atuin/issues/2763