### PR TITLE
[pacman] 7.1.0-2: Default to medium code model on loongarch64

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 pkgbase=pacman
 pkgname=(libalpm pacman repo-tools)
 pkgver=7.1.0
-pkgrel=1
+pkgrel=2
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url=https://www.archlinux.org/pacman/
 license=(GPL)
@@ -81,7 +81,7 @@ build() {
     x86_64) makepkg_cflags+=" -fno-plt -march=x86-64 -fstack-clash-protection -fcf-protection" ;;
     aarch64) makepkg_cflags+=" -fno-plt -march=armv8-a" ;;
     riscv64) makepkg_cflags+=" -march=rv64gc" ;;
-    loongarch64) makepkg_cflags+=" -march=la64v1.0" ;;
+    loongarch64) makepkg_cflags+=" -march=la64v1.0 -mcmodel=medium" ;;
   esac
   case $CARCH in
     riscv64) makepkg_rustarch="riscv64gc" ;;


### PR DESCRIPTION
Old toolchains by default use small code model on loongarch64, which requires the code size to be less than 256MiB, and we're now seeing packages failed to be built for the reason, for example, telegram-desktop.

Default to medium code model to fix the issue. This doesn't break ABI, and will only enlarge packages containing object files/static libraries a little, and has no performance impact, since the linker would shrink (relax) the addressing sequences during linking.