### PR TITLE
[pipewire] 1.4.9-2: Migrate to new dinit syntax

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,6 +4,7 @@ pkgbase=pipewire
 pkgname=(
   pipewire libpipewire
   gst-plugin-pipewire
+  pipewire-docs
 )
 pkgver=1.6.2
 pkgrel=1
@@ -51,8 +52,8 @@ prepare()
 build()
 {
   local features=(
-    -D man=disabled
-    -D docs=disabled
+    -D docs=enabled
+    -D man=enabled
     -D libsystemd=disabled
     -D logind=disabled
     -D systemd-user-service=disabled
@@ -151,6 +152,7 @@ package_pipewire()
   _pick_ lib usr/lib/lib$_pwname.so*
   _pick_ lib usr/lib/pkgconfig/lib{$_pwname,$_spaname}.pc
   _pick_ gst usr/lib/gstreamer-1.0
+  _pick_ doc usr/share/{man,doc}
 }
 
 package_libpipewire() {
@@ -175,3 +177,10 @@ package_gst-plugin-pipewire() {
   install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 $pkgbase-$pkgver/COPYING
 }
 
+package_pipewire-docs() {
+  depends=()
+  pkgdesc+=' - documentation'
+
+  mv pkgs/doc/* "$pkgdir"
+  _install_license_ "$pkgbase-$pkgver"/COPYING
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,8 +5,8 @@ pkgname=(
   pipewire libpipewire
   gst-plugin-pipewire
 )
-pkgver=1.4.9
-pkgrel=2
+pkgver=1.6.2
+pkgrel=1
 pkgdesc="Low-latency audio/video router and processor"
 url="https://pipewire.org"
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -38,7 +38,7 @@ source=(
   pipewire-pulse.user.service
   pipewire.conf.in
 )
-sha256sums=('8066a7b220069e4c6e3b02bd2b6ea303bba66df255023c07c99323449ba8fe3c'
+sha256sums=('2014c187fccdd6d245585be4eda7dabd781dcddd921604c40ab015bba6cb042d'
             'b2b7f7730f1607fccb59248dd48da3eed577afc35feef24faac0193de5832191'
             '2a0807319f60671483de2e015427241d8f9224ccce2616eff143377c0a840193'
             'a1d7812aabba038ff1d90a0af2139f0c420419c5f66ee401b9bc45d0445edfdd')
@@ -53,7 +53,7 @@ build()
   local features=(
     -D man=disabled
     -D docs=disabled
-    -D systemd=disabled
+    -D libsystemd=disabled
     -D logind=disabled
     -D systemd-user-service=disabled
     -D pipewire-jack=disabled
@@ -84,6 +84,7 @@ build()
     -D selinux=disabled
     -D snap=disabled
     -D udevrulesdir=/usr/lib/udev/rules.d
+    -D onnxruntime=disabled
   )
 
   ewe-meson $pkgbase-$pkgver build \


### PR DESCRIPTION
Link: https://github.com/eweOS/packages/issues/6141