### PR TITLE
[meson] 1.10.2-2: add a patch to fix rust's linking problem when target is musl

### DIFF
--- a/001-Fix-self-contained-libs-mistakenly-linked-in-rust.patch
+++ b/001-Fix-self-contained-libs-mistakenly-linked-in-rust.patch
@@ -1,0 +1,120 @@
+From a885210ad2ba3afe12a1d6fa50cf40ebe5b367c6 Mon Sep 17 00:00:00 2001
+From: KCIRREM <merrick@mailfast.org>
+Date: Sat, 21 Mar 2026 02:48:11 +0000
+Subject: [PATCH] build: skip self-contained libs for Rust staticlibs when
+ crt-static is disabled
+
+On musl targets, meson unconditionally adds -L.../self-contained and
+native_static_libs (-lunwind -lc) when linking Rust staticlibs. When
+crt-static is disabled this causes libc.a to be embedded in shared
+libraries, creating a second isolated musl instance that crashes on
+dlopen due to uninitialized __libc state.
+
+Only add self-contained and native_static_libs when crt-static is
+enabled. When disabled, the host libc and other native deps are
+satisfied dynamically.
+
+Fixes: #15645
+---
+ mesonbuild/build.py                           |  8 +++++++-
+ .../rust/39 shared-lib-no-static-libc/lib.rs  |  4 ++++
+ .../rust/39 shared-lib-no-static-libc/main.c  |  6 ++++++
+ .../39 shared-lib-no-static-libc/meson.build  | 19 +++++++++++++++++++
+ .../rust/39 shared-lib-no-static-libc/shim.c  |  5 +++++
+ .../39 shared-lib-no-static-libc/test.json    |  6 ++++++
+ 6 files changed, 47 insertions(+), 1 deletion(-)
+ create mode 100644 test cases/rust/39 shared-lib-no-static-libc/lib.rs
+ create mode 100644 test cases/rust/39 shared-lib-no-static-libc/main.c
+ create mode 100644 test cases/rust/39 shared-lib-no-static-libc/meson.build
+ create mode 100644 test cases/rust/39 shared-lib-no-static-libc/shim.c
+ create mode 100644 test cases/rust/39 shared-lib-no-static-libc/test.json
+
+diff --git a/mesonbuild/build.py b/mesonbuild/build.py
+index 3a5383dddc80..230e69db208f 100644
+--- a/mesonbuild/build.py
++++ b/mesonbuild/build.py
+@@ -2365,7 +2365,13 @@ def post_init(self) -> None:
+                 #  and thus, machine_info kernel should be set to 'none'.
+                 #  In that case, native_static_libs list is empty.
+                 rustc = self.compilers['rust']
+-                link_args = ['-L' + rustc.get_target_libdir() + '/self-contained']
++                if rustc.get_crt_static():
++                    # musl targets need self-contained for libc.a, libunwind.a etc.
++                    link_args = ['-L' + rustc.get_target_libdir() + '/self-contained']
++                else:
++                    # Avoid embedding self-contained libc.a into shared libraries —
++                    # creates a second musl instance with uninitialized __libc state.
++                    link_args = []
+                 link_args += rustc.native_static_libs
+                 d = dependencies.InternalDependency('undefined', [], [], link_args,
+                                                     [], [], [], [], [], {}, [], [], [],
+diff --git a/test cases/rust/39 shared-lib-no-static-libc/lib.rs b/test cases/rust/39 shared-lib-no-static-libc/lib.rs
+new file mode 100644
+index 000000000000..f8a8bf201a22
+--- /dev/null
++++ b/test cases/rust/39 shared-lib-no-static-libc/lib.rs	
+@@ -0,0 +1,4 @@
++#[unsafe(export_name = "hello")]
++pub extern "C" fn hello() {
++    println!("Hello, world!");
++}
+diff --git a/test cases/rust/39 shared-lib-no-static-libc/main.c b/test cases/rust/39 shared-lib-no-static-libc/main.c
+new file mode 100644
+index 000000000000..4a853afc95db
+--- /dev/null
++++ b/test cases/rust/39 shared-lib-no-static-libc/main.c	
+@@ -0,0 +1,6 @@
++extern void shim_hello(void);
++
++int main(void) {
++    shim_hello();
++    return 0;
++}
+diff --git a/test cases/rust/39 shared-lib-no-static-libc/meson.build b/test cases/rust/39 shared-lib-no-static-libc/meson.build
+new file mode 100644
+index 000000000000..f996bc737fed
+--- /dev/null
++++ b/test cases/rust/39 shared-lib-no-static-libc/meson.build	
+@@ -0,0 +1,19 @@
++project('shared-lib-no-static-libc', meson_version : '>= 1.3.0')
++
++if not add_languages('c', native : false, required : false)
++  error('MESON_SKIP_TEST clang not installed')
++endif
++
++if not add_languages('rust', native : false, required : false)
++  error('MESON_SKIP_TEST Rust x86_64-unknown-linux-musl target not installed')
++endif
++
++rust_lib = static_library('hello', 'lib.rs', rust_abi : 'c')
++
++shared = shared_library('hello_shared', 'shim.c',
++  link_whole : rust_lib)
++
++exe = executable('exe', 'main.c',
++  link_with : shared)
++
++test('no-embedded-libc', exe)
+diff --git a/test cases/rust/39 shared-lib-no-static-libc/shim.c b/test cases/rust/39 shared-lib-no-static-libc/shim.c
+new file mode 100644
+index 000000000000..6a13cc6b35e7
+--- /dev/null
++++ b/test cases/rust/39 shared-lib-no-static-libc/shim.c	
+@@ -0,0 +1,5 @@
++extern void hello(void);
++
++void shim_hello(void) {
++    hello();
++}
+diff --git a/test cases/rust/39 shared-lib-no-static-libc/test.json b/test cases/rust/39 shared-lib-no-static-libc/test.json
+new file mode 100644
+index 000000000000..79b8266899c2
+--- /dev/null
++++ b/test cases/rust/39 shared-lib-no-static-libc/test.json	
+@@ -0,0 +1,6 @@
++{
++  "env": {
++    "CC": "clang -target x86_64-unknown-linux-musl",
++    "RUSTC": "rustc --target x86_64-unknown-linux-musl -C target-feature=-crt-static"
++  }
++}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=meson
 pkgver=1.10.2
-pkgrel=1
+pkgrel=2
 pkgdesc='High productivity build system'
 url='https://mesonbuild.com/'
 arch=('any')
@@ -14,15 +14,22 @@ makedepends=(
   python-setuptools
   python-wheel
 )
+# 001: Skip adding rust's self-contained libs with static linking when crt-static arg is disabled.
+# 	this problem may cause panic because there are multi musl libs contained.
+# 	see: https://github.com/mesonbuild/meson/pull/15646
 source=(
   https://github.com/mesonbuild/meson/releases/download/${pkgver}/meson-${pkgver}.tar.gz
+  001-Fix-self-contained-libs-mistakenly-linked-in-rust.patch
   ewe-meson
 )
 sha512sums=('43d408fde7390c81eaef63b835deb4acfcae279cf05bcd63a368c4bc1de69b7fb620f801a7700345d4c41e155a4429a43cdef12e60322aa20a33edfaeb5ce7e9'
+	    '26fd599b020fd384ba9d6e319c9d029798e4216a3b893bdff73e42f9aaacb334d55774d17656dbaabf3c3da22efbef24fa15d8ac75524bc189b5caee1315a90e'
             'e6c3c179c027b54afd9d5340cd14a2e5a291a0e3e9c99bb3ba265f0ae9057adcfae86823536a67e2b1f45309e2c68e0cd9a342c144345c060ad03a450146e297')
 
 build()
 {
+  _patch_ "$pkgname-$pkgver"
+
   cd ${pkgname}-${pkgver}
   python setup.py build
 }


### PR DESCRIPTION
Skip adding rust's self-contained libs with static linking when crt-static arg is disabled. This problem may cause panic because there are multi musl libs contained.

source: https://github.com/mesonbuild/meson/pull/15646