### PR TITLE
[ntbtls] 0.3.2-5: Switch to git.gnupg.org

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ntbtls
 pkgver=0.3.2
-pkgrel=4
+pkgrel=5
 pkgdesc='Not Too Bad TLS library'
 url='https://wiki.gnupg.org/NTBTLS'
 arch=(x86_64 aarch64 riscv64 loongarch64)
@@ -10,7 +10,7 @@ license=(GPL-3.0-or-later)
 depends=(musl libgcrypt libgpg-error libksba)
 makedepends=(git)
 provides=(libntbtls.so)
-source=("git+https://dev.gnupg.org/source/ntbtls.git#tag=ntbtls-$pkgver")
+source=("git+git://git.gnupg.org/ntbtls.git#tag=ntbtls-$pkgver")
 sha256sums=('ad9e26099d5332558e08e6e75c9054349015d54c0695aabfa6d6720254dfd7e9')
 
 build () {


### PR DESCRIPTION
dev.gnupg.org seems currently down.