### PR TITLE
[python-referencing] 0.36-3: Drop dependency on python-pytest-subtests

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=python-referencing
 _pyname=${pkgname#*-}
 _referencingsuite_commit=b74fd4535fed598519d23c8cd74e5e8c77489440
 pkgver=0.36.2
-pkgrel=2
+pkgrel=3
 pkgdesc='An implementation-agnostic implementation of JSON reference resolution'
 url='https://referencing.readthedocs.io/'
 arch=(any)
@@ -12,7 +12,7 @@ license=(MIT)
 depends=(python python-attrs python-rpds-py)
 makedepends=(python-build python-installer python-setuptools python-wheel
 	     python-hatchling python-hatch-vcs git)
-checkdepends=(python-pytest python-pytest-subtests)
+checkdepends=(python-pytest)
 source=("https://github.com/python-jsonschema/referencing/archive/refs/tags/v$pkgver.tar.gz"
 	"git+https://github.com/python-jsonschema/referencing-suite.git#commit=$_referencingsuite_commit")
 sha256sums=('5618f8b72ecac48bbda2b927e6ec7589dfeddcceae01a8d8b64a7a92e4b4417e'


### PR DESCRIPTION
Functionality of this package has been merged into pytest 9.

Link: https://github.com/eweOS/packages/issues/7374