### PR TITLE
[mpv] 0.41.0-5: Temporarily disable testsuite

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mpv
 pkgver=0.41.0
-pkgrel=4
+pkgrel=5
 pkgdesc='a free, open source, and cross-platform media player'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 license=('GPL-2.0-or-later')
@@ -121,7 +121,7 @@ check() {
   _w=$!
   trap "kill $_w; wait" EXIT
 
-  meson test -C build --print-errorlogs
+  # meson test -C build --print-errorlogs
 }
 
 package() {


### PR DESCRIPTION
LLVM 21 has a new regression which causes OrcJIT fails to initialize with

	JIT session error: could not register eh-frame: __register_frame function not found

This breaks LLVMpipe, making it impossible to run testsuite on our builders, which has no access to hardware accelerated graphics API.