### PR TITLE
[mutt] 2.4.1-1: new upstream version, disable the testsuite

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yao Zi <ziyao@disroot.org>
 
 pkgname=mutt
-pkgver=2.3.3
+pkgver=2.4.1
 pkgrel=1
 pkgdesc='The Mutt E-mail Client.'
 url='http://www.mutt.org/'
@@ -10,7 +10,7 @@ license=(GPL-2.0-or-later)
 depends=(ncurses sqlite zlib-ng openssl libsasl gdbm libidn2 gpgme
 	 libgpg-error)
 source=("http://ftp.mutt.org/pub/mutt/mutt-$pkgver.tar.gz")
-sha256sums=('bce753399b28c0efcfa8a446115f0d30d9c27e551ab51b0e53799dd0c373dcc4')
+sha256sums=('5624321f0b1cc1eff6cab9ef08f25954ff64c51b33d4bf3b99484cf1edd8cfff')
 
 build () {
 	cd mutt-$pkgver
@@ -65,10 +65,9 @@ build () {
 	make
 }
 
-check() {
-	cd mutt-$pkgver
-	make check
-}
+# No real testsuite included, the "check" target checks TABs and possible code
+# security problems, and running shellcheck on a script. It seems for
+# development purpose only.
 
 package() {
 	cd mutt-$pkgver


### PR DESCRIPTION
The testsuite is for development purpose.