### PR TITLE
[libglvnd] 1.7.0-6: Make mesa an optional dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=libglvnd
 pkgver=1.7.0
-pkgrel=5
+pkgrel=6
 pkgdesc="The GL Vendor-Neutral Dispatch library"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://gitlab.freedesktop.org/glvnd/libglvnd"
 license=('BSD')
 makedepends=('python' 'meson')
-depends=('mesa')
+optdepends=('mesa: An open-source implementation of graphics and computation APIs')
 provides=('libgl' 'libegl' 'libgles')
 source=("$url/-/archive/v$pkgver/libglvnd-v$pkgver.tar.gz")
 sha512sums=('7b6eb8e075b48f1d915b892044adc3260547d74ed61d1e2fa6c5f0f8c3527754abea314181e088626d4fd58bb221085e5288c4758d828e171c7dcb0e4991745c')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgrel=6
 pkgdesc="The GL Vendor-Neutral Dispatch library"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url="https://gitlab.freedesktop.org/glvnd/libglvnd"
-license=('BSD')
+license=('MIT')
 makedepends=('python' 'meson')
 optdepends=('mesa: An open-source implementation of graphics and computation APIs')
 provides=('libgl' 'libegl' 'libgles')
@@ -35,4 +35,5 @@ build()
 package()
 {
   meson install -C build --destdir "$pkgdir"
+  sed -ne 325,348p $pkgname-v$pkgver/README.md | _install_license_ /dev/stdin
 }


### PR DESCRIPTION
Since libglvnd is technically vendor-netural, and it's totally fine to use libglvnd without mesa.