### PR TITLE
[sqlite] 3.53.4-1: enable more extensions

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ _minorpatchver=${pkgver#3.}
 _minorver=${_minorpatchver%%.*}
 _patchver=${_minorpatchver##*.}
 _srcver="$(printf "3%02d%02d00" "$_minorver" "$_patchver")"
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine"
 arch=(x86_64 aarch64 riscv64 loongarch64)
 license=('blessing')
@@ -21,15 +21,14 @@ build()
 {
   export CFLAGS+=" -DSQLITE_ENABLE_COLUMN_METADATA=1 \
     -DSQLITE_ENABLE_UNLOCK_NOTIFY \
-    -DSQLITE_SECURE_DELETE=1 \
-    -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
-    -DSQLITE_ENABLE_FTS3=1 \
-    -DSQLITE_ENABLE_RTREE=1"
+    -DSQLITE_SECURE_DELETE=1"
 
   # build sqlite
   cd sqlite-autoconf-$_srcver
   ./configure --prefix=/usr \
-    --disable-static
+    --disable-static \
+    --enable-fts3 \
+    --all
   make
 }
 


### PR DESCRIPTION
At least session extension is used by nodejs, so let's enable more.