### PR TITLE
[wlroots0.20] 0.20.2-2: Add mesa dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase=wlroots0.20
 pkgname=(wlroots0.20-devel wlroots0.20)
 pkgver=0.20.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Modular Wayland compositor library'
 license=('MIT')
 url='https://gitlab.freedesktop.org/wlroots/wlroots'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 makedepends=('flex' 'linux-headers' 'meson' 'wayland-protocols' 'hwdata'
-	     'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles'
+	     'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles' 'mesa'
 	     'libegl' 'pixman' 'wayland' 'libdisplay-info' 'lcms2' 'libliftoff'
 	     'libdrm')
 source=("$url/-/releases/$pkgver/downloads/wlroots-$pkgver.tar.gz")
@@ -40,7 +40,7 @@ package_wlroots0.20-devel() {
 package_wlroots0.20() {
     provides=('libwlroots-0.20.so')
     pkgdesc='Modular Wayland compositor library'
-    depends=('libdrm' 'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles'
+    depends=('libdrm' 'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles' 'mesa'
              'libegl' 'pixman' 'wayland' 'libdisplay-info' 'lcms2' 'libliftoff')
 
     mv "$srcdir"/pkgs/libs/* "$pkgdir"


### PR DESCRIPTION
wlroots requires gbm.

After [replacing mesa with libglvnd](https://github.com/eweOS/packages/issues/6238), wlroots's packaging no longer indirectly depend on `mesa`, a runtime crash is then exposed for missing `gbm_*` symbols. In addition, a build failure will be triggered at next build since the build script checks `gbm` as well.

Before this fix, a fresh install with `sway` will trigger this crash.