### PR TITLE
[wlroots0.19] 0.19.3-3: add mesa dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase=wlroots0.19
 pkgname=(wlroots0.19-devel wlroots0.19)
 pkgver=0.19.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Modular Wayland compositor library'
 license=('MIT')
 url='https://gitlab.freedesktop.org/wlroots/wlroots'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 makedepends=('flex' 'linux-headers' 'meson' 'wayland-protocols' 'hwdata'
-	     'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles'
+	     'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles' 'mesa'
 	     'libegl' 'pixman' 'wayland' 'libdisplay-info' 'lcms2' 'libliftoff'
 	     'libdrm')
 source=("$url/-/releases/$pkgver/downloads/wlroots-$pkgver.tar.gz")
@@ -40,7 +40,7 @@ package_wlroots0.19-devel() {
 package_wlroots0.19() {
     provides=('libwlroots-0.19.so')
     pkgdesc='Modular Wayland compositor library'
-    depends=('libdrm' 'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles'
+    depends=('libdrm' 'libinput' 'seatd' 'libudev-zero' 'libxkbcommon' 'libgles' 'mesa'
              'libegl' 'pixman' 'wayland' 'libdisplay-info' 'lcms2' 'libliftoff')
 
     mv "$srcdir"/pkgs/libs/* "$pkgdir"


### PR DESCRIPTION
wlroots requires gbm from mesa.

See also https://github.com/eweOS/packages/pull/8174.