### PR TITLE
[mold] 2.42.0-2: fix: backport upstream fixes

### DIFF
--- a/0001-backport-fix-sym.patch
+++ b/0001-backport-fix-sym.patch
@@ -1,0 +1,60 @@
+From 450832db6b7afaed621c9708bc733afd2edf821b Mon Sep 17 00:00:00 2001
+From: Rui Ueyama <ruiu@cs.stanford.edu>
+Date: Sun, 6 Sep 2026 14:48:51 +0900
+Subject: [PATCH] Make linker-synthesized symbols local again unless exported
+
+35f4a334 changed is_local() to derive a symbol's binding in .symtab from
+its visibility. Linker-synthesized symbols never have their visibility
+merged from the internal object's ELF symbols, so they went from
+STB_LOCAL to STB_GLOBAL by accident. That adds _DYNAMIC, __bss_start,
+_end and the like to the set of global symbols, which confuses ABI
+checkers that read .symtab.
+
+Restore the old rule for the internal object's symbols: they are local
+unless we export them. The exported ones, such as __global_pointer$ on
+RISC-V or __start_*/__stop_* under -z start-stop-visibility=protected,
+stay global as before.
+
+Reported by Yao Zi in https://github.com/rui314/mold/pull/1650
+
+Fixes https://github.com/rui314/mold/issues/1651
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+---
+ src/mold.h             | 5 ++++-
+ test/symtab-binding.sh | 5 +++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/test/symtab-binding.sh b/test/symtab-binding.sh
+index 49f6450de0..db0f9e3196 100755
+--- a/test/symtab-binding.sh
++++ b/test/symtab-binding.sh
+@@ -19,6 +19,11 @@ grep -E 'FUNC    GLOBAL DEFAULT .* global_fn$' $t/log1
+ grep -E 'FUNC    WEAK   DEFAULT .* weak_fn$' $t/log1
+ grep -E 'FUNC    LOCAL  HIDDEN .* hidden_fn$' $t/log1
+ 
++# Linker-synthesized symbols are local unless they are exported.
++grep -E 'NOTYPE  LOCAL  DEFAULT .* _DYNAMIC$' $t/log1
++grep -E 'NOTYPE  LOCAL  DEFAULT .* __ehdr_start$' $t/log1
++grep -E 'NOTYPE  LOCAL  DEFAULT .* _end$' $t/log1
++
+ # A symbol localized by a version script becomes local.
+ echo '{ global: global_fn; local: *; };' > $t/b.ver
+ $CC -B. -shared -o $t/c.so $t/a.o -Wl,--version-script=$t/b.ver
+--- a/src/mold.h
++++ b/src/mold.h
+@@ -3849,10 +3849,14 @@
+ // output symbol table. Note that a symbol that is merely not exported to
+ // the dynamic symbol table is still a global symbol; only ones hidden by
+ // symbol visibility or localized by a version script are demoted.
++// Linker-synthesized symbols are the exception; they are local unless we
++// export them.
+ template <typename E>
+ inline bool Symbol<E>::is_local(Context<E> &ctx) const {
+   if (ctx.arg.relocatable)
+     return esym().st_bind == STB_LOCAL;
++  if (file == ctx.internal_obj)
++    return !is_exported;
+   return visibility == STV_HIDDEN || visibility == STV_INTERNAL ||
+          ver_idx == VER_NDX_LOCAL;
+ }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,15 +2,28 @@
 
 pkgname=mold
 pkgver=2.42.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A Modern Linker'
 arch=(x86_64 aarch64 riscv64 loongarch64)
 url='https://github.com/rui314/mold'
 license=('MIT')
 depends=('musl' 'mimalloc' 'openssl' 'zlib' 'tbb')
 makedepends=('cmake' 'python' 'linux-headers')
-source=("$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('6c0f3308c5b3159a369202d970922ad819bab1bfcb5a3b3c06a723d19f65373e')
+# 0001: backport: fix https://github.com/rui314/mold/issues/1651
+# 0002: backport: claim IR files for LTO in the command line order
+source=(
+  "$url/archive/refs/tags/v$pkgver.tar.gz"
+  "0001-backport-fix-sym.patch"
+  "0002-ir-files-cmdline-order.patch::https://github.com/rui314/mold/commit/92eb17a07c60a88b3a1a8c9cef014ac84eaf0cf9.patch"
+)
+sha256sums=('6c0f3308c5b3159a369202d970922ad819bab1bfcb5a3b3c06a723d19f65373e'
+            'dae7b7d04bc25dfc0e1581afb24f006213ec86d3381a7c562106b02da495e3f0'
+            '92b7500cfaecb2a69cc9903059d8da8be01e90fab91f1e99db6a42707a8a2984')
+
+prepare()
+{
+  _patch_ "$pkgname-$pkgver"
+}
 
 build()
 {


### PR DESCRIPTION
* fix: Some linker-synthesized become STB_GLOBAL
* fix: Claim IR files for LTO in the command line order